### PR TITLE
fix(admin): move session check into layout (follow-up to #48)

### DIFF
--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { useEffect } from 'react'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useIsAdmin } from '@/hooks/use-admin'
+import { useAuth } from '@/lib/auth-context'
 import { FyndstigenLogo } from '@/components/fyndstigen-logo'
 
 const navItems = [
@@ -15,13 +17,27 @@ const navItems = [
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
-  const { data: isAdmin, isLoading } = useIsAdmin()
+  const router = useRouter()
+  const { user, loading: authLoading } = useAuth()
+  const { data: isAdmin, isLoading: adminLoading } = useIsAdmin()
 
-  if (pathname?.startsWith('/admin/invite/accept')) {
+  // Accept-invite page is allowed unauthenticated — it handles its own redirect.
+  const isAcceptPage = pathname?.startsWith('/admin/invite/accept')
+
+  // Redirect unauthenticated users to /auth with a next= back to this path.
+  useEffect(() => {
+    if (isAcceptPage) return
+    if (!authLoading && !user) {
+      const next = encodeURIComponent(pathname ?? '/admin')
+      router.replace(`/auth?next=${next}`)
+    }
+  }, [authLoading, user, pathname, router, isAcceptPage])
+
+  if (isAcceptPage) {
     return <>{children}</>
   }
 
-  if (isLoading) {
+  if (authLoading || adminLoading || !user) {
     return (
       <div className="min-h-dvh flex items-center justify-center">
         <FyndstigenLogo size={40} className="text-rust animate-bob" />

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -3,28 +3,12 @@ import type { NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {
   const host = request.headers.get("host") || "";
+
   if (host.startsWith("www.")) {
     const url = request.nextUrl.clone();
     url.host = host.replace("www.", "");
     url.port = "";
     return NextResponse.redirect(url, 301);
-  }
-
-  const { pathname } = request.nextUrl;
-  if (pathname.startsWith("/admin")) {
-    if (pathname.startsWith("/admin/invite/accept")) return NextResponse.next();
-
-    // Supabase SSR can chunk the auth token into cookies named
-    // `sb-<ref>-auth-token`, `.0`, `.1`, etc. A broad `sb-*` match picks
-    // up all shapes. Layout's is_admin() remains the authoritative gate;
-    // middleware is just a cheap redirect for obviously-unauth traffic.
-    const hasSession = request.cookies.getAll().some((c) => c.name.startsWith("sb-"));
-    if (!hasSession) {
-      const url = request.nextUrl.clone();
-      url.pathname = "/auth";
-      url.searchParams.set("next", pathname + request.nextUrl.search);
-      return NextResponse.redirect(url);
-    }
   }
 }
 


### PR DESCRIPTION
## Why

PR #48 fixed the middleware cookie check but was merged before my follow-up commit landed. The remaining piece: move the auth gate entirely into `/admin/layout.tsx` because the app uses **vanilla `@supabase/supabase-js`** which stores sessions in localStorage — middleware can never see them.

This PR carries only `0d2de18 fix(admin): session check lives in layout, not middleware` on top of main.

## What it does

- Reverts `middleware.ts` to just the www→apex redirect (same as main before #47).
- Extends `/admin/layout.tsx`:
  - Uses `useAuth()` to detect signed-in state (has localStorage visibility).
  - `useEffect` redirects unauthenticated users to `/auth?next=<path>`.
  - Loader while `useAuth` or `useIsAdmin` is in flight.
  - "Otillåten" only when confirmed signed-in but not admin.
  - `/admin/invite/accept` bypass preserved.

## Test plan

- [ ] Signed-in admin navigates to `/admin` → lands on overview (no redirect)
- [ ] Signed-out user navigates to `/admin` → redirected to `/auth?next=/admin`
- [ ] After login, bounced back to `/admin`
- [ ] Non-admin signed in → "Otillåten" panel
- [ ] `/admin/invite/accept?token=xxx` still reachable when signed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)