### PR TITLE
refactor(use-stripe-connect): rebuild on React Query

### DIFF
--- a/web/src/hooks/use-stripe-connect-edge-cases.test.tsx
+++ b/web/src/hooks/use-stripe-connect-edge-cases.test.tsx
@@ -1,19 +1,11 @@
 import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
 import { useStripeConnect } from './use-stripe-connect'
 
 const mockInvokeStatus = vi.fn()
 const mockInvokeCreate = vi.fn()
 const mockInvokeRefresh = vi.fn()
-
-vi.mock('@/lib/api', () => ({
-  api: {
-    endpoints: {
-      'stripe.connect.status': { invoke: (...args: unknown[]) => mockInvokeStatus(...args) },
-      'stripe.connect.create': { invoke: (...args: unknown[]) => mockInvokeCreate(...args) },
-      'stripe.connect.refresh': { invoke: (...args: unknown[]) => mockInvokeRefresh(...args) },
-    },
-  },
-}))
 
 vi.mock('@/lib/edge', () => ({
   edge: { invoke: vi.fn(), invokePublic: vi.fn() },
@@ -24,6 +16,15 @@ vi.mock('@/lib/edge', () => ({
   },
 }))
 
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
 describe('useStripeConnect — edge cases', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -33,25 +34,27 @@ describe('useStripeConnect — edge cases', () => {
     mockInvokeRefresh.mockResolvedValue({ url: '' })
   })
 
-  it('does not fetch status when userId is undefined', async () => {
-    const { result } = renderHook(() => useStripeConnect(undefined))
+  it('does not fetch status when userId is undefined', () => {
+    const { result } = renderHook(() => useStripeConnect(undefined), { wrapper: createWrapper() })
 
     expect(result.current.loading).toBe(false)
     expect(mockInvokeStatus).not.toHaveBeenCalled()
   })
 
-  it('does not fetch status when userId is empty string', async () => {
-    const { result } = renderHook(() => useStripeConnect(undefined))
+  it('does not fetch status when enabled is false', () => {
+    const { result } = renderHook(
+      () => useStripeConnect('user-1', false),
+      { wrapper: createWrapper() },
+    )
 
     expect(result.current.loading).toBe(false)
-    expect(result.current.connected).toBe(false)
-    expect(result.current.onboardingComplete).toBe(false)
+    expect(mockInvokeStatus).not.toHaveBeenCalled()
   })
 
   it('does not redirect on startOnboarding failure', async () => {
     mockInvokeCreate.mockRejectedValueOnce(new Error('Stripe API down'))
 
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     const hrefBefore = window.location.href
@@ -65,7 +68,7 @@ describe('useStripeConnect — edge cases', () => {
     mockInvokeStatus.mockResolvedValue({ connected: true, onboarding_complete: false })
     mockInvokeRefresh.mockRejectedValueOnce(new Error('Account not found'))
 
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => { await result.current.refreshOnboarding() })
@@ -76,7 +79,7 @@ describe('useStripeConnect — edge cases', () => {
   it('clears error when startOnboarding succeeds after failure', async () => {
     mockInvokeCreate.mockRejectedValueOnce(new Error('Temporary failure'))
 
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     await act(async () => { await result.current.startOnboarding() })
@@ -89,7 +92,7 @@ describe('useStripeConnect — edge cases', () => {
   })
 
   it('invokes correct endpoint invokers for each action', async () => {
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     expect(mockInvokeStatus).toHaveBeenCalledWith({})

--- a/web/src/hooks/use-stripe-connect.test.tsx
+++ b/web/src/hooks/use-stripe-connect.test.tsx
@@ -1,20 +1,12 @@
 import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
 import { useStripeConnect } from './use-stripe-connect'
 
 // Mock endpoint invokers
 const mockInvokeStatus = vi.fn()
 const mockInvokeCreate = vi.fn()
 const mockInvokeRefresh = vi.fn()
-
-vi.mock('@/lib/api', () => ({
-  api: {
-    endpoints: {
-      'stripe.connect.status': { invoke: (...args: unknown[]) => mockInvokeStatus(...args) },
-      'stripe.connect.create': { invoke: (...args: unknown[]) => mockInvokeCreate(...args) },
-      'stripe.connect.refresh': { invoke: (...args: unknown[]) => mockInvokeRefresh(...args) },
-    },
-  },
-}))
 
 vi.mock('@/lib/edge', () => ({
   edge: { invoke: vi.fn(), invokePublic: vi.fn() },
@@ -31,6 +23,15 @@ Object.defineProperty(window, 'location', {
   writable: true,
 })
 
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
 describe('useStripeConnect', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -40,12 +41,12 @@ describe('useStripeConnect', () => {
   })
 
   it('returns loading=true initially', () => {
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
     expect(result.current.loading).toBe(true)
   })
 
-  it('returns loading=false with no userId', async () => {
-    const { result } = renderHook(() => useStripeConnect(undefined))
+  it('returns loading=false with no userId', () => {
+    const { result } = renderHook(() => useStripeConnect(undefined), { wrapper: createWrapper() })
     expect(result.current.loading).toBe(false)
     expect(result.current.connected).toBe(false)
   })
@@ -53,7 +54,7 @@ describe('useStripeConnect', () => {
   it('fetches status on mount', async () => {
     mockInvokeStatus.mockResolvedValue({ connected: true, onboarding_complete: true })
 
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
 
     await waitFor(() => expect(result.current.loading).toBe(false))
 
@@ -65,7 +66,7 @@ describe('useStripeConnect', () => {
   it('handles not connected state', async () => {
     mockInvokeStatus.mockResolvedValue({ connected: false, onboarding_complete: false })
 
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
 
     await waitFor(() => expect(result.current.loading).toBe(false))
 
@@ -76,7 +77,7 @@ describe('useStripeConnect', () => {
   it('handles partial onboarding (connected but not complete)', async () => {
     mockInvokeStatus.mockResolvedValue({ connected: true, onboarding_complete: false })
 
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
 
     await waitFor(() => expect(result.current.loading).toBe(false))
 
@@ -87,7 +88,7 @@ describe('useStripeConnect', () => {
   it('sets error on status fetch failure', async () => {
     mockInvokeStatus.mockRejectedValue(new Error('Network error'))
 
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
 
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.error).toBeTruthy()
@@ -97,7 +98,7 @@ describe('useStripeConnect', () => {
     mockInvokeStatus.mockResolvedValue({ connected: false, onboarding_complete: false })
     mockInvokeCreate.mockResolvedValue({ url: 'https://connect.stripe.com/setup/abc' })
 
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
 
     await waitFor(() => expect(result.current.loading).toBe(false))
 
@@ -113,7 +114,7 @@ describe('useStripeConnect', () => {
     mockInvokeStatus.mockResolvedValue({ connected: true, onboarding_complete: false })
     mockInvokeRefresh.mockResolvedValue({ url: 'https://connect.stripe.com/setup/def' })
 
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
 
     await waitFor(() => expect(result.current.loading).toBe(false))
 
@@ -129,7 +130,7 @@ describe('useStripeConnect', () => {
     mockInvokeStatus.mockResolvedValue({ connected: false, onboarding_complete: false })
     mockInvokeCreate.mockRejectedValue(new Error('Failed'))
 
-    const { result } = renderHook(() => useStripeConnect('user-1'))
+    const { result } = renderHook(() => useStripeConnect('user-1'), { wrapper: createWrapper() })
 
     await waitFor(() => expect(result.current.loading).toBe(false))
 

--- a/web/src/hooks/use-stripe-connect.ts
+++ b/web/src/hooks/use-stripe-connect.ts
@@ -1,7 +1,17 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
 import { endpoints } from '@/lib/edge'
+import { queryKeys } from '@/lib/query-keys'
+
+const ERR_STATUS = 'Kunde inte hämta Stripe-status'
+const ERR_START = 'Kunde inte starta Stripe-koppling'
+const ERR_REFRESH = 'Kunde inte generera ny Stripe-länk'
+
+function redirect(url: string): void {
+  window.location.href = url
+}
 
 type ConnectState = {
   connected: boolean
@@ -12,55 +22,61 @@ type ConnectState = {
   refreshOnboarding: () => Promise<void>
 }
 
+/**
+ * Stripe Connect onboarding state for the current user.
+ *
+ * Mirrors the use-takeover.ts pattern: useQuery for the on-mount status
+ * fetch, useMutation for the two redirect actions. The bundled return
+ * shape is preserved so callers (stripe-connect-button, create-market
+ * page) need no changes.
+ */
 export function useStripeConnect(
   userId: string | undefined,
   enabled: boolean = true,
 ): ConnectState {
-  const [connected, setConnected] = useState(false)
-  const [onboardingComplete, setOnboardingComplete] = useState(false)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
 
-  useEffect(() => {
-    if (!enabled || !userId) {
-      setLoading(false)
-      return
-    }
-    checkStatus()
-  }, [userId, enabled])
+  const status = useQuery({
+    queryKey: queryKeys.stripeConnect.status(userId),
+    queryFn: () => endpoints['stripe.connect.status'].invoke({}),
+    enabled: enabled && !!userId,
+    retry: false,
+  })
 
-  async function checkStatus() {
-    try {
-      setLoading(true)
-      const data = await endpoints['stripe.connect.status'].invoke({})
-      setConnected(data.connected)
-      setOnboardingComplete(data.onboarding_complete)
-    } catch {
-      setError('Kunde inte hämta Stripe-status')
-    } finally {
-      setLoading(false)
-    }
+  const start = useMutation({
+    mutationFn: () => endpoints['stripe.connect.create'].invoke({}),
+    onSuccess: ({ url }) => redirect(url),
+    onError: () => setActionError(ERR_START),
+  })
+
+  const refresh = useMutation({
+    mutationFn: () => endpoints['stripe.connect.refresh'].invoke({}),
+    onSuccess: ({ url }) => redirect(url),
+    onError: () => setActionError(ERR_REFRESH),
+  })
+
+  const error = actionError ?? (status.isError ? ERR_STATUS : null)
+
+  return {
+    connected: status.data?.connected ?? false,
+    onboardingComplete: status.data?.onboarding_complete ?? false,
+    loading: !!userId && enabled && status.isPending,
+    error,
+    startOnboarding: async () => {
+      setActionError(null)
+      try {
+        await start.mutateAsync()
+      } catch {
+        // onError already set the error
+      }
+    },
+    refreshOnboarding: async () => {
+      setActionError(null)
+      try {
+        await refresh.mutateAsync()
+      } catch {
+        // onError already set the error
+      }
+    },
   }
-
-  async function startOnboarding() {
-    try {
-      setError(null)
-      const data = await endpoints['stripe.connect.create'].invoke({})
-      window.location.href = data.url
-    } catch {
-      setError('Kunde inte starta Stripe-koppling')
-    }
-  }
-
-  async function refreshOnboarding() {
-    try {
-      setError(null)
-      const data = await endpoints['stripe.connect.refresh'].invoke({})
-      window.location.href = data.url
-    } catch {
-      setError('Kunde inte generera ny Stripe-länk')
-    }
-  }
-
-  return { connected, onboardingComplete, loading, error, startOnboarding, refreshOnboarding }
 }

--- a/web/src/lib/query-keys.ts
+++ b/web/src/lib/query-keys.ts
@@ -52,6 +52,10 @@ export const queryKeys = {
   takeover: {
     info: (token: string | null) => ['takeover', 'info', token] as const,
   },
+  stripeConnect: {
+    status: (userId: string | undefined) =>
+      ['stripe-connect', 'status', userId] as const,
+  },
   blockSales: {
     all: () => ['blockSales'] as const,
     bySlug: (slug: string) => ['blockSales', 'slug', slug] as const,


### PR DESCRIPTION
## Summary

- Replace manual \`useEffect\` + \`useState\` with \`useQuery\` for the on-mount status fetch.
- Replace manual try/catch in \`startOnboarding\` / \`refreshOnboarding\` with \`useMutation\` + \`onSuccess\` / \`onError\`.
- Centralize redirect-on-success into a single \`redirect(url)\` helper.
- Centralize the three error messages as module-level constants.
- Add \`stripeConnect.status\` query key.

The bundled \`ConnectState\` return shape is preserved so callers (\`stripe-connect-button\`, \`profile/create-market\`) need no changes. Test files renamed to \`.tsx\` and now wrap in \`QueryClientProvider\`.

Closes #81

## Test plan

- [x] Hook tests: 15/15 pass locally
- [x] Web vitest: 277/277 pass locally (1 pre-existing transform error in src/lib/supabase.ts, unchanged)
- [x] Web tsc --noEmit: clean
- [ ] CI: deno-check + check-edge-imports + view-refreshes + test + lighthouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)