### PR TITLE
refactor(auth): collapse pass-through methods into auth-with-redirect factory

### DIFF
--- a/web/src/app/auth/page.tsx
+++ b/web/src/app/auth/page.tsx
@@ -9,7 +9,8 @@ import { FyndstigenLogo } from '@/components/fyndstigen-logo'
 export default function AuthPage() {
   const router = useRouter()
   const posthog = usePostHog()
-  const { user, signIn, signUp, signInWithGoogle, resetPasswordForEmail } = useAuth()
+  const { user, auth } = useAuth()
+  const { signIn, signUp, signInWithGoogle, resetPasswordForEmail } = auth
   const [mode, setMode] = useState<'signin' | 'signup' | 'forgot'>('signin')
   const [resetSent, setResetSent] = useState(false)
   const [nextPath, setNextPath] = useState('/utforska')

--- a/web/src/app/auth/reset-password/page.tsx
+++ b/web/src/app/auth/reset-password/page.tsx
@@ -9,7 +9,8 @@ import { FyndstigenLogo } from '@/components/fyndstigen-logo'
 
 export default function ResetPasswordPage() {
   const router = useRouter()
-  const { updatePassword } = useAuth()
+  const { auth } = useAuth()
+  const { updatePassword } = auth
   const [ready, setReady] = useState(false)
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -15,7 +15,8 @@ import { useFlag } from '@/lib/flags'
 
 export default function ProfilePage() {
   const router = useRouter()
-  const { user, signOut, loading: authLoading } = useAuth()
+  const { user, auth, loading: authLoading } = useAuth()
+  const { signOut } = auth
   const { markets: myMarkets, loading: marketsLoading } = useMarketsByOrganizer(user?.id)
   const { routes: myRoutes, loading: routesLoading } = useRoutesByUser(user?.id)
   const { count: pendingCount } = usePendingBookingsCount(user?.id)

--- a/web/src/lib/auth-context.test.tsx
+++ b/web/src/lib/auth-context.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { render, renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockAuth, mockGetSession, mockOnAuthStateChange } = vi.hoisted(() => {
+  const getSession = vi.fn()
+  const onAuthStateChange = vi.fn()
+  return {
+    mockGetSession: getSession,
+    mockOnAuthStateChange: onAuthStateChange,
+    mockAuth: {
+      getSession,
+      onAuthStateChange,
+      signIn: vi.fn(),
+      signUp: vi.fn(),
+      signInWithGoogle: vi.fn(),
+      signOut: vi.fn(),
+      resetPasswordForEmail: vi.fn(),
+      updatePassword: vi.fn(),
+    },
+  }
+})
+
+vi.mock('./auth', () => ({ auth: mockAuth }))
+
+import { AuthProvider, useAuth } from './auth-context'
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({ user: null })
+    mockOnAuthStateChange.mockReturnValue(() => {})
+  })
+
+  it('returns the auth singleton even outside a provider (no-throw default)', () => {
+    const { result } = renderHook(() => useAuth())
+    expect(result.current.auth).toBe(mockAuth)
+    expect(result.current.user).toBe(null)
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('inside provider, exposes user from getSession after resolve', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', email: 'a@b.com' } })
+
+    function Probe() {
+      const { user, loading } = useAuth()
+      return <div data-testid="probe">{loading ? 'loading' : user?.email ?? 'none'}</div>
+    }
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(getByTestId('probe').textContent).toBe('a@b.com'))
+  })
+
+  it('subscribes to auth state changes and updates user', async () => {
+    let cb: ((u: { id: string; email: string } | null) => void) | undefined
+    mockOnAuthStateChange.mockImplementation((fn: (u: { id: string; email: string } | null) => void) => {
+      cb = fn
+      return () => {}
+    })
+
+    function Probe() {
+      const { user } = useAuth()
+      return <div data-testid="probe">{user?.email ?? 'none'}</div>
+    }
+
+    const { getByTestId } = render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => expect(mockOnAuthStateChange).toHaveBeenCalled())
+    expect(cb).toBeDefined()
+
+    cb!({ id: 'u2', email: 'b@c.com' })
+    await waitFor(() => expect(getByTestId('probe').textContent).toBe('b@c.com'))
+  })
+})

--- a/web/src/lib/auth-context.tsx
+++ b/web/src/lib/auth-context.tsx
@@ -8,32 +8,18 @@ import {
   ReactNode,
 } from 'react'
 import type { AuthUser } from '@fyndstigen/shared'
-import { auth } from './auth'
+import { auth, type AuthWithRedirect } from './auth'
 
 type AuthState = {
   user: AuthUser | null
   loading: boolean
-  signIn: (email: string, password: string) => Promise<void>
-  signUp: (
-    email: string,
-    password: string,
-    metadata?: Record<string, string>,
-  ) => Promise<{ needsEmailConfirmation: boolean }>
-  signInWithGoogle: () => Promise<void>
-  signOut: () => Promise<void>
-  resetPasswordForEmail: (email: string) => Promise<void>
-  updatePassword: (password: string) => Promise<void>
+  auth: AuthWithRedirect
 }
 
 const AuthContext = createContext<AuthState>({
   user: null,
   loading: true,
-  signIn: async () => {},
-  signUp: async () => ({ needsEmailConfirmation: false }),
-  signInWithGoogle: async () => {},
-  signOut: async () => {},
-  resetPasswordForEmail: async () => {},
-  updatePassword: async () => {},
+  auth,
 })
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -45,47 +31,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(u)
       setLoading(false)
     })
-
-    const unsubscribe = auth.onAuthStateChange(setUser)
-    return unsubscribe
+    return auth.onAuthStateChange(setUser)
   }, [])
 
-  async function signIn(email: string, password: string) {
-    await auth.signIn(email, password)
-  }
-
-  async function signUp(
-    email: string,
-    password: string,
-    metadata?: Record<string, string>,
-  ) {
-    const redirectTo =
-      typeof window !== 'undefined' ? `${window.location.origin}/auth` : undefined
-    return auth.signUp(email, password, metadata, redirectTo)
-  }
-
-  async function signInWithGoogle() {
-    await auth.signInWithGoogle()
-  }
-
-  async function signOut() {
-    await auth.signOut()
-  }
-
-  async function resetPasswordForEmail(email: string) {
-    const redirectTo =
-      typeof window !== 'undefined'
-        ? `${window.location.origin}/auth/reset-password`
-        : ''
-    await auth.resetPasswordForEmail(email, redirectTo)
-  }
-
-  async function updatePassword(password: string) {
-    await auth.updatePassword(password)
-  }
-
   return (
-    <AuthContext.Provider value={{ user, loading, signIn, signUp, signInWithGoogle, signOut, resetPasswordForEmail, updatePassword }}>
+    <AuthContext.Provider value={{ user, loading, auth }}>
       {children}
     </AuthContext.Provider>
   )

--- a/web/src/lib/auth-with-redirect.test.ts
+++ b/web/src/lib/auth-with-redirect.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { AuthPort } from '@fyndstigen/shared/ports/auth'
+import { wrapAuth } from './auth-with-redirect'
+
+function makePort(): AuthPort & { _spies: Record<string, ReturnType<typeof vi.fn>> } {
+  const spies = {
+    getSession: vi.fn(async () => ({ user: null })),
+    onAuthStateChange: vi.fn(() => () => {}),
+    signIn: vi.fn(async () => undefined),
+    signUp: vi.fn(async () => ({ needsEmailConfirmation: false })),
+    signInWithGoogle: vi.fn(async () => undefined),
+    signOut: vi.fn(async () => undefined),
+    resetPasswordForEmail: vi.fn(async () => undefined),
+    updatePassword: vi.fn(async () => undefined),
+  }
+  return { ...spies, _spies: spies }
+}
+
+describe('wrapAuth', () => {
+  it('signUp injects `${origin}/auth` as emailRedirectTo', async () => {
+    const port = makePort()
+    const wrapped = wrapAuth(port, () => 'https://app.example.com')
+    await wrapped.signUp('a@b.com', 'pw', { firstName: 'Eva' })
+    expect(port._spies.signUp).toHaveBeenCalledWith(
+      'a@b.com',
+      'pw',
+      { firstName: 'Eva' },
+      'https://app.example.com/auth',
+    )
+  })
+
+  it('resetPasswordForEmail injects `${origin}/auth/reset-password`', async () => {
+    const port = makePort()
+    const wrapped = wrapAuth(port, () => 'https://app.example.com')
+    await wrapped.resetPasswordForEmail('a@b.com')
+    expect(port._spies.resetPasswordForEmail).toHaveBeenCalledWith(
+      'a@b.com',
+      'https://app.example.com/auth/reset-password',
+    )
+  })
+
+  it('uses originProvider lazily so each call reads the current origin', async () => {
+    const port = makePort()
+    let origin = 'https://staging.example.com'
+    const wrapped = wrapAuth(port, () => origin)
+
+    await wrapped.signUp('a@b.com', 'pw')
+    expect(port._spies.signUp).toHaveBeenLastCalledWith(
+      'a@b.com', 'pw', undefined, 'https://staging.example.com/auth',
+    )
+
+    origin = 'https://app.example.com'
+    await wrapped.signUp('a@b.com', 'pw')
+    expect(port._spies.signUp).toHaveBeenLastCalledWith(
+      'a@b.com', 'pw', undefined, 'https://app.example.com/auth',
+    )
+  })
+
+  it('signIn passes through unchanged', async () => {
+    const port = makePort()
+    const wrapped = wrapAuth(port, () => 'irrelevant')
+    await wrapped.signIn('a@b.com', 'pw')
+    expect(port._spies.signIn).toHaveBeenCalledWith('a@b.com', 'pw')
+  })
+
+  it('signInWithGoogle passes through unchanged (port handles redirect)', async () => {
+    const port = makePort()
+    const wrapped = wrapAuth(port, () => 'irrelevant')
+    await wrapped.signInWithGoogle('https://example.com/cb')
+    expect(port._spies.signInWithGoogle).toHaveBeenCalledWith('https://example.com/cb')
+  })
+
+  it('signOut, updatePassword, getSession, onAuthStateChange pass through', async () => {
+    const port = makePort()
+    const wrapped = wrapAuth(port, () => 'irrelevant')
+    await wrapped.signOut()
+    await wrapped.updatePassword('newpw')
+    await wrapped.getSession()
+    wrapped.onAuthStateChange(() => {})
+    expect(port._spies.signOut).toHaveBeenCalled()
+    expect(port._spies.updatePassword).toHaveBeenCalledWith('newpw')
+    expect(port._spies.getSession).toHaveBeenCalled()
+    expect(port._spies.onAuthStateChange).toHaveBeenCalled()
+  })
+})

--- a/web/src/lib/auth-with-redirect.ts
+++ b/web/src/lib/auth-with-redirect.ts
@@ -1,0 +1,55 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createSupabaseAuth } from '@fyndstigen/shared'
+import type { AuthPort } from '@fyndstigen/shared/ports/auth'
+
+/**
+ * Auth surface for web callers.
+ *
+ * Same as `AuthPort` except `signUp` and `resetPasswordForEmail` no longer
+ * require a `redirectTo` — the wrapping factory injects one derived from the
+ * caller's origin. This is the only added behavior; everything else is a
+ * direct passthrough.
+ */
+export type AuthWithRedirect = Omit<AuthPort, 'signUp' | 'resetPasswordForEmail'> & {
+  signUp(
+    email: string,
+    password: string,
+    metadata?: Record<string, string>,
+  ): Promise<{ needsEmailConfirmation: boolean }>
+  resetPasswordForEmail(email: string): Promise<void>
+}
+
+/**
+ * Wrap an `AuthPort` (or a Supabase client) so `signUp` and
+ * `resetPasswordForEmail` derive their `redirectTo` from the injected
+ * `originProvider`. Tests can inject a stub origin; the production caller
+ * passes `() => window.location.origin`.
+ */
+export function createAuthWithRedirect(
+  supabase: SupabaseClient,
+  originProvider: () => string,
+): AuthWithRedirect {
+  return wrapAuth(createSupabaseAuth(supabase), originProvider)
+}
+
+/**
+ * Same as `createAuthWithRedirect` but accepts an existing `AuthPort` —
+ * exposed so unit tests can drive the wrap without touching Supabase.
+ */
+export function wrapAuth(
+  port: AuthPort,
+  originProvider: () => string,
+): AuthWithRedirect {
+  return {
+    getSession: port.getSession.bind(port),
+    onAuthStateChange: port.onAuthStateChange.bind(port),
+    signIn: port.signIn.bind(port),
+    signInWithGoogle: port.signInWithGoogle.bind(port),
+    signOut: port.signOut.bind(port),
+    updatePassword: port.updatePassword.bind(port),
+    signUp: (email, password, metadata) =>
+      port.signUp(email, password, metadata, `${originProvider()}/auth`),
+    resetPasswordForEmail: (email) =>
+      port.resetPasswordForEmail(email, `${originProvider()}/auth/reset-password`),
+  }
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,3 +1,9 @@
-import { createSupabaseAuth } from '@fyndstigen/shared'
+import { createAuthWithRedirect, type AuthWithRedirect } from './auth-with-redirect'
 import { supabase } from './supabase'
-export const auth = createSupabaseAuth(supabase)
+
+export type { AuthWithRedirect }
+
+export const auth: AuthWithRedirect = createAuthWithRedirect(
+  supabase,
+  () => (typeof window !== 'undefined' ? window.location.origin : ''),
+)


### PR DESCRIPTION
## Summary

- New \`createAuthWithRedirect(supabase, originProvider)\` factory wraps an \`AuthPort\` and injects \`redirectTo\` into \`signUp\` and \`resetPasswordForEmail\`. Origin is dependency-injected so the factory is unit-testable without \`window\`.
- \`web/src/lib/auth.ts\` exports the wrapped singleton.
- \`web/src/lib/auth-context.tsx\` shrinks from 94 LOC to ~45: state + provider, context value \`{ user, loading, auth }\`. The 8 empty-stub methods on the default context value are replaced with the real \`auth\` singleton.
- 3 call sites updated: \`useAuth().method()\` → \`useAuth().auth.method()\` (\`auth/page.tsx\`, \`profile/page.tsx\`, \`auth/reset-password/page.tsx\`). All other call sites only used \`{ user, loading }\` and need no change.

Closes #82

## Test plan

- [x] 6 new tests in \`auth-with-redirect.test.ts\` (signUp / reset inject, other methods pass through, origin lazy)
- [x] 3 new tests in \`auth-context.test.tsx\` (default value, getSession integration, onAuthStateChange wiring)
- [x] Web vitest: 303/303 pass locally
- [x] Web tsc --noEmit: clean
- [ ] CI: deno-check + check-edge-imports + view-refreshes + test + lighthouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)