### PR TITLE
refactor(route-builder): extract orchestration into useRouteBuilder hook

### DIFF
--- a/web/src/components/route-builder.tsx
+++ b/web/src/components/route-builder.tsx
@@ -1,263 +1,42 @@
 'use client'
 
-import { useEffect, useState, useCallback, useRef } from 'react'
-import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { geo } from '@/lib/geo'
-import { useDeps } from '@/providers/deps-provider'
-import type { FleaMarketNearBy } from '@fyndstigen/shared'
+import { useRouteBuilder } from '@/hooks/use-route-builder'
 import { useAuth } from '@/lib/auth-context'
-import { usePostHog } from 'posthog-js/react'
-import type { OpeningHourRule, OpeningHourException, Stop } from '@fyndstigen/shared'
-import { runRouteMutation } from '@fyndstigen/shared'
 import { FyndstigenLogo } from './fyndstigen-logo'
 import { RouteFormFields } from './route-builder/route-form-fields'
 import { StopList, type RouteBuilderStop } from './route-builder/stop-list'
 import { RouteMap } from './route-builder/route-map'
 import { SaveRouteButton } from './route-builder/save-route-button'
 import { AnonSaveForm } from './route-builder/anon-save-form'
+import type { FleaMarketNearBy } from '@fyndstigen/shared'
+import type { OpeningHourRule, OpeningHourException } from '@fyndstigen/shared'
 
 type MarketWithHours = FleaMarketNearBy & {
   opening_hour_rules?: OpeningHourRule[]
   opening_hour_exceptions?: OpeningHourException[]
 }
 
-// ---------------------------------------------------------------------------
-// localStorage draft
-// ---------------------------------------------------------------------------
-
-const DRAFT_KEY = 'fyndstigen.route-draft.v1'
-const DRAFT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
-
-type RouteDraft = {
-  name: string
-  plannedDate: string
-  useGps: boolean
-  customStart: { lat: number; lng: number } | null
-  stops: Array<{ marketId: string; index: number }>
-  savedAt: string // ISO
-}
-
-function readDraft(): RouteDraft | null {
-  try {
-    const raw = localStorage.getItem(DRAFT_KEY)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as RouteDraft
-    if (!parsed.savedAt) return null
-    const age = Date.now() - Date.parse(parsed.savedAt)
-    if (age > DRAFT_MAX_AGE_MS) {
-      localStorage.removeItem(DRAFT_KEY)
-      return null
-    }
-    return parsed
-  } catch {
-    return null
-  }
-}
-
-function writeDraft(draft: RouteDraft): void {
-  try {
-    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft))
-  } catch {
-    // localStorage unavailable (private browsing / quota exceeded) — no-op
-  }
-}
-
-export function clearDraft(): void {
-  try {
-    localStorage.removeItem(DRAFT_KEY)
-  } catch {
-    // no-op
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
-
 export default function RouteBuilder() {
-  const router = useRouter()
+  const vm = useRouteBuilder()
   const { user } = useAuth()
-  const posthog = usePostHog()
-  const { routes } = useDeps()
 
-  const [markets, setMarkets] = useState<MarketWithHours[]>([])
-  const [stops, setStops] = useState<RouteBuilderStop[]>([])
-  const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
-  const [saveError, setSaveError] = useState('')
-  const [name, setName] = useState('')
-  const [plannedDate, setPlannedDate] = useState('')
-  const [useGps, setUseGps] = useState(true)
-  const [customStart, setCustomStart] = useState<{ lat: number; lng: number } | null>(null)
-  const [userPos, setUserPos] = useState<{ lat: number; lng: number } | null>(null)
+  const loading = vm.markets === undefined
 
-  // Whether we've already attempted to restore from localStorage
-  const draftRestoredRef = useRef(false)
-
-  // Load markets
-  useEffect(() => {
-    // National radius — see map-view.tsx for the rationale. The route
-    // builder filters by user-selected area client-side anyway.
-    geo.nearbyMarkets({ lat: 59.27, lng: 15.21 }, 2000)
-      .then((data) => setMarkets(data ?? []))
-      .catch(() => setMarkets([]))
-      .finally(() => setLoading(false))
-  }, [])
-
-  // Restore draft from localStorage once markets have loaded
-  useEffect(() => {
-    if (draftRestoredRef.current) return
-    if (markets.length === 0) return // wait until markets are available
-
-    draftRestoredRef.current = true
-    const draft = readDraft()
-    if (!draft) return
-
-    setName(draft.name)
-    setPlannedDate(draft.plannedDate)
-    setUseGps(draft.useGps)
-    setCustomStart(draft.customStart)
-
-    const resolved: RouteBuilderStop[] = []
-    for (const s of draft.stops) {
-      const market = markets.find((m) => m.id === s.marketId)
-      if (market) resolved.push({ market, index: s.index })
-    }
-    if (resolved.length > 0) {
-      setStops(resolved)
-      const ageMins = Math.round((Date.now() - Date.parse(draft.savedAt)) / 60_000)
-      posthog?.capture('route_draft_restored', {
-        stop_count: resolved.length,
-        age_minutes: ageMins,
-      })
-    }
-  }, [markets, posthog])
-
-  // Persist draft to localStorage whenever relevant state changes (debounced)
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(() => {
-    if (stops.length === 0) return // nothing worth persisting
-
-    if (debounceTimer.current) clearTimeout(debounceTimer.current)
-    debounceTimer.current = setTimeout(() => {
-      writeDraft({
-        name,
-        plannedDate,
-        useGps,
-        customStart,
-        stops: stops.map((s) => ({ marketId: s.market.id, index: s.index })),
-        savedAt: new Date().toISOString(),
-      })
-    }, 250)
-
-    return () => {
-      if (debounceTimer.current) clearTimeout(debounceTimer.current)
-    }
-  }, [name, plannedDate, useGps, customStart, stops])
-
-  // Get user GPS
-  useEffect(() => {
-    if (useGps && navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (pos) => setUserPos({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
-        () => {},
-      )
-    }
-  }, [useGps])
-
-  const isInRoute = useCallback(
-    (marketId: string) => stops.some((s) => s.market.id === marketId),
-    [stops],
-  )
-
-  function toggleMarket(market: MarketWithHours) {
-    if (isInRoute(market.id)) {
-      setStops((prev) => prev.filter((s) => s.market.id !== market.id))
-    } else {
-      setStops((prev) => [...prev, { market, index: prev.length }])
-      posthog?.capture('route_market_added', {
-        flea_market_id: market.id,
-        market_name: market.name,
-        market_city: market.city,
-      })
-    }
+  // StopList passes the full reordered array; the hook expects (from, to).
+  // StopList does a single splice per dragover, so exactly one element will be
+  // out of place compared to vm.stops. Find it and delegate.
+  function handleReorder(newStops: RouteBuilderStop[]) {
+    const toIdx = newStops.findIndex((s, i) => s.market.id !== vm.stops[i]?.market.id)
+    if (toIdx === -1) return
+    const fromIdx = vm.stops.findIndex((s) => s.market.id === newStops[toIdx].market.id)
+    if (fromIdx !== toIdx) vm.reorderStops(fromIdx, toIdx)
   }
 
-  function handleOptimize() {
-    if (stops.length < 2) return
-    const asStops: Stop[] = stops.map((s) => ({
-      id: s.market.id,
-      lat: s.market.latitude,
-      lng: s.market.longitude,
-    }))
-    const startPoint =
-      !useGps && customStart ? customStart : userPos ? userPos : undefined
-    const optimized = geo.optimizeStops(asStops, startPoint)
-    setStops(
-      optimized.map((opt, i) => ({
-        market: stops.find((s) => s.market.id === opt.id)!.market,
-        index: i,
-      })),
-    )
-  }
-
-  // Track when an anon user has built a real route but is blocked by the
-  // login wall — this is the suspected dropoff point (see commit history).
-  // Fires once per build session, not per re-render.
-  const [loginBlockedReported, setLoginBlockedReported] = useState(false)
-  useEffect(() => {
-    if (!user && stops.length > 0 && !loginBlockedReported) {
-      posthog?.capture('route_login_blocked', { stop_count: stops.length })
-      setLoginBlockedReported(true)
-    }
-  }, [user, stops.length, posthog, loginBlockedReported])
-
-  async function handleSave() {
-    if (!user || !name.trim() || stops.length === 0) return
-    posthog?.capture('route_save_attempted', { stop_count: stops.length })
-    setSaving(true)
-    setSaveError('')
-
-    const startLat = !useGps && customStart ? customStart.lat : userPos?.lat
-    const startLng = !useGps && customStart ? customStart.lng : userPos?.lng
-
-    const plan = {
-      route: {
-        create: {
-          name: name.trim(),
-          createdBy: user.id,
-          startLatitude: startLat,
-          startLongitude: startLng,
-          plannedDate: plannedDate || undefined,
-        },
-      },
-      stops: {
-        add: stops.map((s) => ({ fleaMarketId: s.market.id })),
-        remove: [] as string[],
-      },
-    }
-
-    for await (const ev of runRouteMutation(plan, { api: { routes } })) {
-      if ('type' in ev) {
-        if (ev.type === 'complete') {
-          posthog?.capture('route_saved', {
-            route_id: ev.routeId,
-            stop_count: stops.length,
-            market_ids: stops.map((s) => s.market.id),
-          })
-          clearDraft()
-          router.push(`/rundor/${ev.routeId}`)
-        } else {
-          // ev.type === 'failed'
-          posthog?.capture('route_save_failed', { stop_count: stops.length, reason: (ev as { reason?: string }).reason ?? 'unknown' })
-          setSaveError('Kunde inte spara rundan. Försök igen.')
-          setSaving(false)
-        }
-        return
-      }
-    }
-  }
+  const saveError =
+    vm.saveProgress && 'type' in vm.saveProgress && vm.saveProgress.type === 'failed'
+      ? 'Kunde inte spara rundan. Försök igen.'
+      : ''
 
   return (
     <div className="flex flex-col lg:flex-row" style={{ height: 'calc(100dvh - 64px)' }}>
@@ -287,45 +66,43 @@ export default function RouteBuilder() {
           </p>
 
           <RouteFormFields
-            name={name}
-            onNameChange={setName}
-            plannedDate={plannedDate}
-            onPlannedDateChange={setPlannedDate}
-            useGps={useGps}
-            onUseGpsChange={setUseGps}
+            name={vm.name}
+            onNameChange={vm.setName}
+            plannedDate={vm.plannedDate}
+            onPlannedDateChange={vm.setPlannedDate}
+            useGps={vm.useGps}
+            onUseGpsChange={vm.setUseGps}
           />
 
           <StopList
-            stops={stops}
-            plannedDate={plannedDate}
-            onReorder={setStops}
-            onRemove={(marketId) =>
-              setStops((prev) => prev.filter((s) => s.market.id !== marketId))
-            }
-            onOptimize={handleOptimize}
-            canOptimize={stops.length >= 2}
+            stops={vm.stops}
+            plannedDate={vm.plannedDate}
+            onReorder={handleReorder}
+            onRemove={vm.removeStop}
+            onOptimize={vm.optimize}
+            canOptimize={vm.stops.length >= 2}
           />
 
           {user ? (
             <SaveRouteButton
-              disabled={!name.trim() || stops.length === 0}
-              saving={saving}
+              disabled={!vm.name.trim() || vm.stops.length === 0}
+              saving={vm.isSaving}
               error={saveError}
-              onSave={handleSave}
+              onSave={vm.save}
             />
-          ) : stops.length > 0 ? (
+          ) : vm.stops.length > 0 ? (
             <div className="mt-6 vintage-card p-4 space-y-3">
               <p className="text-sm font-semibold text-espresso">
-                Du har {stops.length} stopp på din runda — spara den så du inte tappar bort den.
+                Du har {vm.stops.length} stopp på din runda — spara den så du inte tappar bort den.
               </p>
               <AnonSaveForm
-                stops={stops}
-                name={name}
-                plannedDate={plannedDate}
-                useGps={useGps}
-                customStart={customStart}
-                userPos={userPos}
-                onSaved={clearDraft}
+                stops={vm.stops}
+                name={vm.name}
+                plannedDate={vm.plannedDate}
+                useGps={vm.useGps}
+                customStart={vm.customStart}
+                userPos={vm.userPos}
+                onSaved={vm.clearDraft}
               />
               <p className="text-xs text-espresso/60 text-center">
                 Eller{' '}
@@ -356,12 +133,12 @@ export default function RouteBuilder() {
           </div>
         )}
         <RouteMap
-          markets={markets}
-          stops={stops}
-          onToggleMarket={toggleMarket}
-          useGps={useGps}
-          customStart={customStart}
-          onCustomStartChange={setCustomStart}
+          markets={(vm.markets ?? []) as MarketWithHours[]}
+          stops={vm.stops}
+          onToggleMarket={(market) => vm.toggleStop(market.id)}
+          useGps={vm.useGps}
+          customStart={vm.customStart}
+          onCustomStartChange={vm.setCustomStart}
         />
       </div>
     </div>

--- a/web/src/hooks/route-builder/draft.ts
+++ b/web/src/hooks/route-builder/draft.ts
@@ -1,0 +1,47 @@
+// Draft persistence helpers — moved here from route-builder.tsx.
+// Pure functions; no React imports so they can be tested in isolation.
+
+export const DRAFT_KEY = 'fyndstigen.route-draft.v1'
+export const DRAFT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+export type RouteDraft = {
+  name: string
+  plannedDate: string
+  useGps: boolean
+  customStart: { lat: number; lng: number } | null
+  stops: Array<{ marketId: string; index: number }>
+  savedAt: string // ISO
+}
+
+export function readDraft(storage: Storage, now: () => number): RouteDraft | null {
+  try {
+    const raw = storage.getItem(DRAFT_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as RouteDraft
+    if (!parsed.savedAt) return null
+    const age = now() - Date.parse(parsed.savedAt)
+    if (age > DRAFT_MAX_AGE_MS) {
+      storage.removeItem(DRAFT_KEY)
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function writeDraft(storage: Storage, draft: RouteDraft): void {
+  try {
+    storage.setItem(DRAFT_KEY, JSON.stringify(draft))
+  } catch {
+    // localStorage unavailable (private browsing / quota exceeded) — no-op
+  }
+}
+
+export function clearDraft(storage: Storage): void {
+  try {
+    storage.removeItem(DRAFT_KEY)
+  } catch {
+    // no-op
+  }
+}

--- a/web/src/hooks/route-builder/use-draft-persistence.ts
+++ b/web/src/hooks/route-builder/use-draft-persistence.ts
@@ -1,0 +1,93 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import type { FleaMarketNearBy } from '@fyndstigen/shared'
+import type { RouteBuilderStop } from '@/components/route-builder/stop-list'
+import { readDraft, writeDraft, clearDraft as clearDraftFn, DRAFT_KEY } from './draft'
+import type { RouteDraft } from './draft'
+
+export type { RouteDraft }
+export { DRAFT_KEY }
+
+type PostHogLike = { capture: (event: string, props?: Record<string, unknown>) => void }
+
+type DraftState = {
+  name: string
+  plannedDate: string
+  useGps: boolean
+  customStart: { lat: number; lng: number } | null
+  stops: RouteBuilderStop[]
+}
+
+export function useDraftPersistence(
+  markets: FleaMarketNearBy[] | undefined,
+  state: DraftState,
+  setName: (v: string) => void,
+  setPlannedDate: (v: string) => void,
+  setUseGps: (v: boolean) => void,
+  setCustomStart: (v: { lat: number; lng: number } | null) => void,
+  setStops: (v: RouteBuilderStop[]) => void,
+  storage: Storage,
+  posthog: PostHogLike | undefined,
+  now: () => number,
+) {
+  const restoredRef = useRef(false)
+
+  // One-shot restore: waits for markets to load, then applies saved draft once.
+  useEffect(() => {
+    if (restoredRef.current) return
+    if (!markets || markets.length === 0) return
+
+    restoredRef.current = true
+    const draft = readDraft(storage, now)
+    if (!draft) return
+
+    setName(draft.name)
+    setPlannedDate(draft.plannedDate)
+    setUseGps(draft.useGps)
+    setCustomStart(draft.customStart)
+
+    const resolved: RouteBuilderStop[] = []
+    for (const s of draft.stops) {
+      const market = markets.find((m) => m.id === s.marketId)
+      if (market) resolved.push({ market, index: s.index })
+    }
+    if (resolved.length > 0) {
+      setStops(resolved)
+      const ageMins = Math.round((now() - Date.parse(draft.savedAt)) / 60_000)
+      posthog?.capture('route_draft_restored', {
+        stop_count: resolved.length,
+        age_minutes: ageMins,
+      })
+    }
+  // setName, setPlannedDate, setUseGps, setCustomStart, setStops are all stable
+  // useState setter references — omitting them from deps avoids spurious re-runs.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [markets, storage, posthog, now])
+
+  // Debounced persist: writes on any change to relevant state, skips empty stops.
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (state.stops.length === 0) return
+
+    if (debounceTimer.current) clearTimeout(debounceTimer.current)
+    debounceTimer.current = setTimeout(() => {
+      writeDraft(storage, {
+        name: state.name,
+        plannedDate: state.plannedDate,
+        useGps: state.useGps,
+        customStart: state.customStart,
+        stops: state.stops.map((s) => ({ marketId: s.market.id, index: s.index })),
+        savedAt: new Date(now()).toISOString(),
+      })
+    }, 250)
+
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current)
+    }
+  }, [state.name, state.plannedDate, state.useGps, state.customStart, state.stops, storage, now])
+
+  return {
+    clearDraft: () => clearDraftFn(storage),
+  }
+}

--- a/web/src/hooks/route-builder/use-gps-reader.ts
+++ b/web/src/hooks/route-builder/use-gps-reader.ts
@@ -1,0 +1,39 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import type { LatLng } from '@fyndstigen/shared'
+
+/**
+ * Watches the `useGps` flag and fires `getCurrentPosition` only on the
+ * `false → true` edge (including the initial mount when useGps starts true).
+ */
+export function useGpsReader(
+  useGps: boolean,
+  geolocation: Geolocation | undefined,
+): { userPos: LatLng | null; gpsError: string | null } {
+  const [userPos, setUserPos] = useState<LatLng | null>(null)
+  const [gpsError, setGpsError] = useState<string | null>(null)
+  const prevUseGpsRef = useRef<boolean | null>(null)
+
+  useEffect(() => {
+    const wasGps = prevUseGpsRef.current
+    prevUseGpsRef.current = useGps
+
+    // Fire only on false → true edge (including initial mount where prev is null)
+    const risingEdge = useGps && (wasGps === null || wasGps === false)
+    if (!risingEdge) return
+    if (!geolocation) return
+
+    geolocation.getCurrentPosition(
+      (pos) => {
+        setUserPos({ lat: pos.coords.latitude, lng: pos.coords.longitude })
+        setGpsError(null)
+      },
+      () => {
+        setGpsError('GPS ej tillgänglig — kontrollera behörigheter.')
+      },
+    )
+  }, [useGps, geolocation])
+
+  return { userPos, gpsError }
+}

--- a/web/src/hooks/route-builder/use-markets-query.ts
+++ b/web/src/hooks/route-builder/use-markets-query.ts
@@ -1,0 +1,17 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import type { FleaMarketNearBy, GeoService } from '@fyndstigen/shared'
+
+// Sweden center — national radius. The route builder filters client-side.
+const SWEDEN_CENTER = { lat: 59.27, lng: 15.21 }
+const RADIUS_KM = 2000
+
+export function useMarketsQuery(geo: GeoService) {
+  const { data } = useQuery<FleaMarketNearBy[]>({
+    queryKey: ['route-builder', 'markets'],
+    queryFn: () => geo.nearbyMarkets(SWEDEN_CENTER, RADIUS_KM),
+    staleTime: Infinity,
+  })
+  return data
+}

--- a/web/src/hooks/route-builder/use-route-save.ts
+++ b/web/src/hooks/route-builder/use-route-save.ts
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState } from 'react'
+import { runRouteMutation } from '@fyndstigen/shared'
+import type { RouteEvent } from '@fyndstigen/shared'
+import type { LatLng, AuthUser } from '@fyndstigen/shared'
+import type { RouteRepository } from '@fyndstigen/shared'
+import type { RouteBuilderStop } from '@/components/route-builder/stop-list'
+
+export type RouteSaveProgress = RouteEvent
+
+type PostHogLike = { capture: (event: string, props?: Record<string, unknown>) => void }
+
+type SaveDeps = {
+  routes: RouteRepository
+  posthog: PostHogLike | undefined
+  router: { push: (href: string) => void }
+  user: AuthUser | null | undefined
+  onClearDraft: () => void
+}
+
+export function useRouteSave(deps: SaveDeps) {
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveProgress, setSaveProgress] = useState<RouteSaveProgress | null>(null)
+
+  function save(
+    name: string,
+    plannedDate: string,
+    useGps: boolean,
+    customStart: LatLng | null,
+    userPos: LatLng | null,
+    stops: RouteBuilderStop[],
+  ) {
+    const { routes, posthog, router, user, onClearDraft } = deps
+    if (!user || !name.trim() || stops.length === 0) return
+
+    posthog?.capture('route_save_attempted', { stop_count: stops.length })
+    setIsSaving(true)
+    setSaveProgress(null)
+
+    const startLat = !useGps && customStart ? customStart.lat : userPos?.lat
+    const startLng = !useGps && customStart ? customStart.lng : userPos?.lng
+
+    const plan = {
+      route: {
+        create: {
+          name: name.trim(),
+          createdBy: user.id,
+          startLatitude: startLat,
+          startLongitude: startLng,
+          plannedDate: plannedDate || undefined,
+        },
+      },
+      stops: {
+        add: stops.map((s) => ({ fleaMarketId: s.market.id })),
+        remove: [] as string[],
+      },
+    }
+
+    async function run() {
+      for await (const ev of runRouteMutation(plan, { api: { routes } })) {
+        setSaveProgress(ev)
+        if ('type' in ev) {
+          if (ev.type === 'complete') {
+            posthog?.capture('route_saved', {
+              route_id: ev.routeId,
+              stop_count: stops.length,
+              market_ids: stops.map((s) => s.market.id),
+            })
+            onClearDraft()
+            setIsSaving(false)
+            router.push(`/rundor/${ev.routeId}`)
+          } else {
+            posthog?.capture('route_save_failed', {
+              stop_count: stops.length,
+              reason: (ev as { error?: { message?: string } }).error?.message ?? 'unknown',
+            })
+            setIsSaving(false)
+          }
+          return
+        }
+      }
+    }
+
+    run().catch(() => {
+      posthog?.capture('route_save_failed', { stop_count: stops.length, reason: 'unknown' })
+      setIsSaving(false)
+    })
+  }
+
+  return { isSaving, saveProgress, save }
+}

--- a/web/src/hooks/use-route-builder.test.tsx
+++ b/web/src/hooks/use-route-builder.test.tsx
@@ -1,0 +1,669 @@
+'use client'
+
+import React from 'react'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { useRouteBuilder } from './use-route-builder'
+import type { RouteBuilderDeps } from './use-route-builder'
+import type { FleaMarketNearBy, GeoService } from '@fyndstigen/shared'
+
+// ---------------------------------------------------------------------------
+// Mock next/navigation — must be hoisted
+// ---------------------------------------------------------------------------
+const mockRouterPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock posthog-js/react — must be hoisted
+// ---------------------------------------------------------------------------
+const mockCapture = vi.fn()
+vi.mock('posthog-js/react', () => ({
+  usePostHog: () => ({ capture: mockCapture }),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock DepsProvider + useAuth — hook pulls these unconditionally but tests
+// inject everything via deps override, so we just need silent stubs.
+// ---------------------------------------------------------------------------
+vi.mock('@/providers/deps-provider', () => ({
+  useDeps: () => ({
+    routes: {
+      create: vi.fn(),
+      get: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      publish: vi.fn(),
+      unpublish: vi.fn(),
+      listByUser: vi.fn(),
+      listPopular: vi.fn(),
+    },
+  }),
+}))
+
+vi.mock('@/lib/auth-context', () => ({
+  useAuth: () => ({ user: null }),
+}))
+
+// Mock the geo module so the test doesn't transitively load @/lib/supabase
+// (which throws under jsdom without env vars). Tests inject geo via deps.
+vi.mock('@/lib/geo', () => ({
+  geo: {
+    nearbyMarkets: vi.fn(async () => []),
+    optimizeStops: vi.fn((stops) => stops),
+    geocode: vi.fn(),
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SEED_MARKET: FleaMarketNearBy = {
+  id: 'm1',
+  name: 'Loppis A',
+  description: '',
+  city: 'Testköping',
+  is_permanent: false,
+  latitude: 59.3,
+  longitude: 18.0,
+  distance_km: 1,
+  published_at: '2024-01-01T00:00:00Z',
+}
+
+const SEED_MARKET_2: FleaMarketNearBy = {
+  id: 'm2',
+  name: 'Loppis B',
+  description: '',
+  city: 'Testköping',
+  is_permanent: false,
+  latitude: 59.4,
+  longitude: 18.1,
+  distance_km: 2,
+  published_at: '2024-01-01T00:00:00Z',
+}
+
+function makeStorage(): Storage & { _data: Map<string, string> } {
+  const _data = new Map<string, string>()
+  return {
+    _data,
+    getItem: (k: string) => _data.get(k) ?? null,
+    setItem: (k: string, v: string) => { _data.set(k, v) },
+    removeItem: (k: string) => { _data.delete(k) },
+    clear: () => { _data.clear() },
+    key: (i: number) => Array.from(_data.keys())[i] ?? null,
+    get length() { return _data.size },
+  }
+}
+
+function makeRoutesPort(overrides?: Partial<RouteBuilderDeps['routes']>): RouteBuilderDeps['routes'] {
+  return {
+    create: vi.fn().mockResolvedValue({ id: 'rt-1' }),
+    get: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    publish: vi.fn(),
+    unpublish: vi.fn(),
+    listByUser: vi.fn(),
+    listPopular: vi.fn().mockResolvedValue([SEED_MARKET, SEED_MARKET_2]),
+    ...overrides,
+  }
+}
+
+function makeGeoPort(overrides?: Partial<GeoService>): GeoService {
+  return {
+    geocode: vi.fn(),
+    nearbyMarkets: vi.fn().mockResolvedValue([SEED_MARKET, SEED_MARKET_2]),
+    calculateRoute: vi.fn().mockResolvedValue(null),
+    optimizeStops: vi.fn().mockImplementation((stops) => [...stops].reverse()),
+    ...overrides,
+  }
+}
+
+function makeGeolocation(overrides?: Partial<Geolocation>): Geolocation {
+  return {
+    getCurrentPosition: vi.fn(),
+    watchPosition: vi.fn(),
+    clearWatch: vi.fn(),
+    ...overrides,
+  }
+}
+
+function makeDeps(overrides?: Partial<RouteBuilderDeps>): RouteBuilderDeps {
+  return {
+    routes: makeRoutesPort(),
+    geo: makeGeoPort(),
+    storage: makeStorage(),
+    geolocation: makeGeolocation(),
+    posthog: { capture: mockCapture },
+    router: { push: mockRouterPush },
+    user: null,
+    now: () => Date.now(),
+    ...overrides,
+  }
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useRealTimers()
+})
+
+describe('useRouteBuilder — markets fetched on mount', () => {
+  it('fetches markets from geo port on mount', async () => {
+    const deps = makeDeps()
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.markets).toBeUndefined()
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    expect(result.current.markets).toHaveLength(2)
+    expect((deps.geo as GeoService).nearbyMarkets).toHaveBeenCalledOnce()
+  })
+})
+
+describe('useRouteBuilder — draft restore', () => {
+  const DRAFT_KEY = 'fyndstigen.route-draft.v1'
+
+  it('skips restore when markets are not yet loaded', async () => {
+    const storage = makeStorage()
+    const geo = makeGeoPort({ nearbyMarkets: vi.fn().mockResolvedValue([]) })
+    const savedAt = new Date(Date.now() - 60_000).toISOString()
+    storage.setItem(DRAFT_KEY, JSON.stringify({
+      name: 'Saved',
+      plannedDate: '',
+      useGps: true,
+      customStart: null,
+      stops: [{ marketId: 'm1', index: 0 }],
+      savedAt,
+    }))
+
+    const deps = makeDeps({ geo, storage })
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    // markets is empty, so stops should not be restored
+    expect(result.current.stops).toHaveLength(0)
+    expect(result.current.name).toBe('')
+  })
+
+  it('restores draft once markets are loaded', async () => {
+    const storage = makeStorage()
+    const savedAt = new Date(Date.now() - 60_000).toISOString()
+    storage.setItem(DRAFT_KEY, JSON.stringify({
+      name: 'Mina loppis',
+      plannedDate: '2025-06-10',
+      useGps: false,
+      customStart: { lat: 59.1, lng: 18.0 },
+      stops: [{ marketId: 'm1', index: 0 }],
+      savedAt,
+    }))
+
+    const deps = makeDeps({ storage })
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.stops).toHaveLength(1))
+    expect(result.current.name).toBe('Mina loppis')
+    expect(result.current.plannedDate).toBe('2025-06-10')
+    expect(result.current.useGps).toBe(false)
+    expect(result.current.customStart).toEqual({ lat: 59.1, lng: 18.0 })
+  })
+
+  it('honors 7-day TTL and discards expired draft', async () => {
+    const storage = makeStorage()
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+    storage.setItem(DRAFT_KEY, JSON.stringify({
+      name: 'Old draft',
+      plannedDate: '',
+      useGps: true,
+      customStart: null,
+      stops: [{ marketId: 'm1', index: 0 }],
+      savedAt: eightDaysAgo,
+    }))
+
+    const deps = makeDeps({ storage })
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    // Wait a tick for the restore effect to run
+    await waitFor(() => expect(result.current.markets!.length).toBeGreaterThan(0))
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(result.current.name).toBe('')
+    expect(result.current.stops).toHaveLength(0)
+    // Expired entry should have been purged
+    expect(storage.getItem(DRAFT_KEY)).toBeNull()
+  })
+
+  it('fires route_draft_restored exactly once with correct age_minutes', async () => {
+    const storage = makeStorage()
+    const now = Date.now()
+    const ninetyMinsAgo = now - 90 * 60 * 1000
+    const savedAt = new Date(ninetyMinsAgo).toISOString()
+    storage.setItem(DRAFT_KEY, JSON.stringify({
+      name: 'Draft',
+      plannedDate: '',
+      useGps: true,
+      customStart: null,
+      stops: [{ marketId: 'm1', index: 0 }],
+      savedAt,
+    }))
+
+    const deps = makeDeps({
+      storage,
+      now: () => now,
+    })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.stops).toHaveLength(1))
+
+    expect(mockCapture).toHaveBeenCalledWith('route_draft_restored', {
+      stop_count: 1,
+      age_minutes: 90,
+    })
+
+    // Re-render should NOT fire it again
+    mockCapture.mockClear()
+    act(() => {
+      result.current.setName('Updated')
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    expect(mockCapture).not.toHaveBeenCalledWith('route_draft_restored', expect.anything())
+  })
+})
+
+describe('useRouteBuilder — draft persist', () => {
+  const DRAFT_KEY = 'fyndstigen.route-draft.v1'
+
+  it('does not write to storage when stops are empty', async () => {
+    const storage = makeStorage()
+    const deps = makeDeps({ storage })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    act(() => { result.current.setName('Test name') })
+
+    // Wait well past the 250ms debounce — no stops means nothing persisted
+    await new Promise((r) => setTimeout(r, 400))
+    expect(storage.getItem(DRAFT_KEY)).toBeNull()
+  })
+
+  it('debounces persist at 250ms and writes after delay', async () => {
+    const storage = makeStorage()
+    const deps = makeDeps({ storage })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+
+    // Switch to fake timers after markets have loaded (real timers were needed
+    // for React Query's async resolution above).
+    vi.useFakeTimers()
+
+    // Add a stop so the persist effect fires
+    act(() => { result.current.toggleStop('m1') })
+
+    // Before the debounce fires
+    act(() => { vi.advanceTimersByTime(100) })
+    expect(storage.getItem(DRAFT_KEY)).toBeNull()
+
+    // After the full 250ms debounce
+    act(() => { vi.advanceTimersByTime(200) })
+    expect(storage.getItem(DRAFT_KEY)).not.toBeNull()
+
+    const stored = JSON.parse(storage.getItem(DRAFT_KEY)!)
+    expect(stored.stops).toHaveLength(1)
+    expect(stored.stops[0].marketId).toBe('m1')
+    vi.useRealTimers()
+  })
+})
+
+describe('useRouteBuilder — GPS', () => {
+  it('calls getCurrentPosition only when useGps transitions false→true', async () => {
+    const geolocation = makeGeolocation({
+      getCurrentPosition: vi.fn(),
+    })
+    const deps = makeDeps({ geolocation, user: null })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+
+    // Default useGps is true. GPS should have been called once on mount.
+    expect(geolocation.getCurrentPosition).toHaveBeenCalledOnce()
+
+    // Setting same value (true → true) should not trigger another call
+    act(() => { result.current.setUseGps(true) })
+    expect(geolocation.getCurrentPosition).toHaveBeenCalledOnce()
+
+    // Turn off then on: false → true should call again
+    act(() => { result.current.setUseGps(false) })
+    act(() => { result.current.setUseGps(true) })
+    expect(geolocation.getCurrentPosition).toHaveBeenCalledTimes(2)
+  })
+
+  it('sets gpsError on permission denial without throwing', async () => {
+    const geolocation = makeGeolocation({
+      getCurrentPosition: vi.fn().mockImplementation((_success, error) => {
+        error({ code: 1, message: 'Permission denied' } as GeolocationPositionError)
+      }),
+    })
+    const deps = makeDeps({ geolocation })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.gpsError).not.toBeNull())
+    expect(result.current.gpsError).toContain('GPS')
+  })
+})
+
+describe('useRouteBuilder — save (auth user)', () => {
+  it('emits route_save_attempted → route_saved and redirects on complete', async () => {
+    const routes = makeRoutesPort()
+    const user = { id: 'user-1', email: 'test@test.se' }
+    const deps = makeDeps({ routes, user })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+
+    act(() => {
+      result.current.toggleStop('m1')
+      result.current.setName('Min runda')
+    })
+
+    await act(async () => {
+      result.current.save()
+      // Allow the async generator to run
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    expect(mockCapture).toHaveBeenCalledWith('route_save_attempted', { stop_count: 1 })
+    expect(mockCapture).toHaveBeenCalledWith('route_saved', expect.objectContaining({ route_id: 'rt-1' }))
+    expect(mockRouterPush).toHaveBeenCalledWith('/rundor/rt-1')
+  })
+
+  it('clears draft on successful save', async () => {
+    const DRAFT_KEY = 'fyndstigen.route-draft.v1'
+    const storage = makeStorage()
+    const routes = makeRoutesPort()
+    const user = { id: 'user-1', email: 'test@test.se' }
+    const deps = makeDeps({ routes, user, storage })
+
+    // Pre-populate storage with a draft
+    storage.setItem(DRAFT_KEY, JSON.stringify({
+      name: 'Old',
+      plannedDate: '',
+      useGps: true,
+      customStart: null,
+      stops: [{ marketId: 'm1', index: 0 }],
+      savedAt: new Date().toISOString(),
+    }))
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.stops).toHaveLength(1))
+
+    act(() => { result.current.setName('Min runda') })
+
+    await act(async () => {
+      result.current.save()
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    expect(storage.getItem(DRAFT_KEY)).toBeNull()
+  })
+
+  it('emits route_save_failed with reason on failure', async () => {
+    const routes = makeRoutesPort({
+      create: vi.fn().mockRejectedValue(new Error('network error')),
+    })
+    const user = { id: 'user-1', email: 'test@test.se' }
+    const deps = makeDeps({ routes, user })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    act(() => {
+      result.current.toggleStop('m1')
+      result.current.setName('Min runda')
+    })
+
+    await act(async () => {
+      result.current.save()
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    expect(mockCapture).toHaveBeenCalledWith('route_save_failed', expect.objectContaining({
+      stop_count: 1,
+    }))
+    // draft should be preserved on failure
+    expect(result.current.stops).toHaveLength(1)
+  })
+})
+
+describe('useRouteBuilder — anon path', () => {
+  it('fires route_login_blocked exactly once per session for unauth user with stops', async () => {
+    const deps = makeDeps({ user: null })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+
+    act(() => { result.current.toggleStop('m1') })
+    await waitFor(() =>
+      expect(mockCapture).toHaveBeenCalledWith('route_login_blocked', expect.any(Object))
+    )
+    const callCount = mockCapture.mock.calls.filter(
+      ([event]) => event === 'route_login_blocked'
+    ).length
+    expect(callCount).toBe(1)
+
+    // Re-trigger by changing name — should NOT fire again
+    act(() => { result.current.setName('changed') })
+    await new Promise((r) => setTimeout(r, 50))
+
+    const callCountAfter = mockCapture.mock.calls.filter(
+      ([event]) => event === 'route_login_blocked'
+    ).length
+    expect(callCountAfter).toBe(1)
+  })
+
+  it('does not fire route_login_blocked when stops is empty', async () => {
+    const deps = makeDeps({ user: null })
+
+    renderHook(() => useRouteBuilder({ deps }), { wrapper: createWrapper() })
+
+    await new Promise((r) => setTimeout(r, 100))
+    expect(mockCapture).not.toHaveBeenCalledWith('route_login_blocked', expect.any(Object))
+  })
+})
+
+describe('useRouteBuilder — optimize', () => {
+  it('is a no-op below 2 stops', async () => {
+    const geo = makeGeoPort()
+    const deps = makeDeps({ geo })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    act(() => { result.current.toggleStop('m1') })
+
+    await act(async () => { await result.current.optimize() })
+
+    expect((geo as GeoService).optimizeStops).not.toHaveBeenCalled()
+    expect(result.current.stops).toHaveLength(1)
+  })
+
+  it('reorders stops via geo.optimizeStops with correct startPoint (GPS)', async () => {
+    const geolocation = makeGeolocation({
+      getCurrentPosition: vi.fn().mockImplementation((success) => {
+        success({ coords: { latitude: 59.0, longitude: 18.0 } } as GeolocationPosition)
+      }),
+    })
+    const geo = makeGeoPort({
+      optimizeStops: vi.fn().mockImplementation((stops) => [...stops].reverse()),
+    })
+    const deps = makeDeps({ geo, geolocation })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    act(() => {
+      result.current.toggleStop('m1')
+      result.current.toggleStop('m2')
+    })
+
+    await act(async () => { await result.current.optimize() })
+
+    expect((geo as GeoService).optimizeStops).toHaveBeenCalledWith(
+      expect.any(Array),
+      { lat: 59.0, lng: 18.0 },
+    )
+    // Should be reversed (mock returns reversed)
+    expect(result.current.stops[0].market.id).toBe('m2')
+    expect(result.current.stops[1].market.id).toBe('m1')
+  })
+
+  it('reorders stops via geo.optimizeStops with correct startPoint (custom)', async () => {
+    const geo = makeGeoPort({
+      optimizeStops: vi.fn().mockImplementation((stops) => [...stops].reverse()),
+    })
+    const deps = makeDeps({ geo })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    act(() => {
+      result.current.setUseGps(false)
+      result.current.setCustomStart({ lat: 60.0, lng: 17.0 })
+      result.current.toggleStop('m1')
+      result.current.toggleStop('m2')
+    })
+
+    await act(async () => { await result.current.optimize() })
+
+    expect((geo as GeoService).optimizeStops).toHaveBeenCalledWith(
+      expect.any(Array),
+      { lat: 60.0, lng: 17.0 },
+    )
+  })
+
+  it('passes undefined startPoint when no GPS pos and no custom start', async () => {
+    const geo = makeGeoPort({
+      optimizeStops: vi.fn().mockImplementation((stops) => stops),
+    })
+    const geolocation = makeGeolocation({
+      getCurrentPosition: vi.fn(), // never calls success
+    })
+    const deps = makeDeps({ geo, geolocation })
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    act(() => {
+      result.current.setUseGps(false)
+      result.current.toggleStop('m1')
+      result.current.toggleStop('m2')
+    })
+
+    await act(async () => { await result.current.optimize() })
+
+    expect((geo as GeoService).optimizeStops).toHaveBeenCalledWith(
+      expect.any(Array),
+      undefined,
+    )
+  })
+})
+
+describe('useRouteBuilder — toggleStop fires route_market_added', () => {
+  it('fires route_market_added when adding a new market', async () => {
+    const deps = makeDeps()
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    act(() => { result.current.toggleStop('m1') })
+
+    expect(mockCapture).toHaveBeenCalledWith('route_market_added', expect.objectContaining({
+      flea_market_id: 'm1',
+    }))
+  })
+
+  it('does not fire route_market_added when removing a market', async () => {
+    const deps = makeDeps()
+
+    const { result } = renderHook(() => useRouteBuilder({ deps }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.markets).toBeDefined())
+    act(() => { result.current.toggleStop('m1') })
+    mockCapture.mockClear()
+    act(() => { result.current.toggleStop('m1') })
+
+    expect(mockCapture).not.toHaveBeenCalledWith('route_market_added', expect.anything())
+  })
+})
+
+describe('useRouteBuilder — mode guard', () => {
+  it('throws when mode is edit (not yet implemented)', () => {
+    expect(() => {
+      const deps = makeDeps()
+      renderHook(() => useRouteBuilder({ mode: 'edit', deps }), {
+        wrapper: createWrapper(),
+      })
+    }).toThrow()
+  })
+})

--- a/web/src/hooks/use-route-builder.ts
+++ b/web/src/hooks/use-route-builder.ts
@@ -1,0 +1,237 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { usePostHog } from 'posthog-js/react'
+import { useDeps } from '@/providers/deps-provider'
+import { useAuth } from '@/lib/auth-context'
+import { geo as defaultGeo } from '@/lib/geo'
+import type { FleaMarketNearBy, GeoService, LatLng, AuthUser } from '@fyndstigen/shared'
+import type { RouteRepository } from '@fyndstigen/shared'
+import type { Stop } from '@fyndstigen/shared'
+import type { RouteBuilderStop } from '@/components/route-builder/stop-list'
+import { useMarketsQuery } from './route-builder/use-markets-query'
+import { useDraftPersistence } from './route-builder/use-draft-persistence'
+import { useGpsReader } from './route-builder/use-gps-reader'
+import { useRouteSave } from './route-builder/use-route-save'
+import type { RouteSaveProgress } from './route-builder/use-route-save'
+
+export type { RouteSaveProgress }
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+type PostHogLike = { capture: (event: string, props?: Record<string, unknown>) => void }
+
+export type RouteBuilderDeps = {
+  routes?: RouteRepository
+  geo?: GeoService
+  storage?: Storage
+  geolocation?: Geolocation
+  posthog?: PostHogLike
+  router?: { push: (href: string) => void }
+  user?: AuthUser | null
+  now?: () => number
+}
+
+export interface RouteBuilderState {
+  name: string
+  setName: (v: string) => void
+  plannedDate: string
+  setPlannedDate: (v: string) => void
+  useGps: boolean
+  setUseGps: (v: boolean) => void
+  customStart: LatLng | null
+  setCustomStart: (v: LatLng | null) => void
+  stops: RouteBuilderStop[]
+  toggleStop: (marketId: string) => void
+  reorderStops: (from: number, to: number) => void
+  removeStop: (marketId: string) => void
+  optimize: () => Promise<void>
+  save: () => void
+  saveAnon: (email: string) => void
+  clearDraft: () => void
+  markets: FleaMarketNearBy[] | undefined
+  isOptimizing: boolean
+  isSaving: boolean
+  saveProgress: RouteSaveProgress | null
+  gpsError: string | null
+  /** GPS-resolved user position (set when useGps=true and permission granted) */
+  userPos: LatLng | null
+}
+
+export interface RouteBuilderOptions {
+  /** Only 'new' is implemented in this PR. */
+  mode?: 'new' | 'edit'
+  onSaved?: (slug: string) => void
+  /** Test-only override — injects fake implementations for all dependencies. */
+  deps?: RouteBuilderDeps
+}
+
+// ---------------------------------------------------------------------------
+// Dependency resolution
+// ---------------------------------------------------------------------------
+
+function resolveDeps(
+  override: RouteBuilderDeps | undefined,
+  ctxDeps: ReturnType<typeof useDeps>,
+  user: AuthUser | null,
+  posthog: ReturnType<typeof usePostHog>,
+  router: { push: (href: string) => void },
+): Required<RouteBuilderDeps> {
+  return {
+    routes: override?.routes ?? ctxDeps.routes,
+    geo: override?.geo ?? defaultGeo,
+    storage: override?.storage ?? globalThis.localStorage,
+    geolocation: override?.geolocation ?? globalThis.navigator?.geolocation,
+    posthog: override?.posthog ?? posthog ?? undefined,
+    router: override?.router ?? router,
+    user: 'user' in (override ?? {}) ? (override!.user ?? null) : user,
+    now: override?.now ?? Date.now,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useRouteBuilder(opts?: RouteBuilderOptions): RouteBuilderState {
+  if (opts?.mode === 'edit') {
+    // TODO: edit mode requires routeId + initialDraft hydration (YAGNI — implement in follow-up)
+    // eslint-disable-next-line no-restricted-syntax -- programming invariant: edit mode not yet implemented
+    throw new Error('useRouteBuilder: edit mode is not yet implemented')
+  }
+
+  const router = useRouter()
+  const { user } = useAuth()
+  const posthog = usePostHog()
+  const ctxDeps = useDeps()
+
+  const deps = resolveDeps(opts?.deps, ctxDeps, user, posthog, router)
+
+  // --- Core state ---
+  const [name, setName] = useState('')
+  const [plannedDate, setPlannedDate] = useState('')
+  const [useGps, setUseGps] = useState(true)
+  const [customStart, setCustomStart] = useState<LatLng | null>(null)
+  const [stops, setStops] = useState<RouteBuilderStop[]>([])
+  const [isOptimizing, setIsOptimizing] = useState(false)
+
+  // --- Markets ---
+  const markets = useMarketsQuery(deps.geo)
+
+  // --- GPS ---
+  const { userPos, gpsError } = useGpsReader(useGps, deps.geolocation)
+
+  // --- Draft persistence ---
+  const { clearDraft } = useDraftPersistence(
+    markets,
+    { name, plannedDate, useGps, customStart, stops },
+    setName,
+    setPlannedDate,
+    setUseGps,
+    setCustomStart,
+    setStops,
+    deps.storage,
+    deps.posthog,
+    deps.now,
+  )
+
+  // --- Save ---
+  const { isSaving, saveProgress, save: runSave } = useRouteSave({
+    routes: deps.routes,
+    posthog: deps.posthog,
+    router: deps.router,
+    user: deps.user,
+    onClearDraft: clearDraft,
+  })
+
+  // --- Anon login-blocked telemetry (one-shot per session) ---
+  const loginBlockedReportedRef = useRef(false)
+  useEffect(() => {
+    if (!deps.user && stops.length > 0 && !loginBlockedReportedRef.current) {
+      deps.posthog?.capture('route_login_blocked', { stop_count: stops.length })
+      loginBlockedReportedRef.current = true
+    }
+  }, [deps.user, stops.length, deps.posthog])
+
+  // --- Stop mutations ---
+  const toggleStop = useCallback((marketId: string) => {
+    setStops((prev) => {
+      const exists = prev.some((s) => s.market.id === marketId)
+      if (exists) {
+        return prev.filter((s) => s.market.id !== marketId)
+      }
+      const market = markets?.find((m) => m.id === marketId)
+      if (!market) return prev
+      deps.posthog?.capture('route_market_added', {
+        flea_market_id: market.id,
+        market_name: market.name,
+        market_city: market.city,
+      })
+      return [...prev, { market, index: prev.length }]
+    })
+  }, [markets, deps.posthog])
+
+  const reorderStops = useCallback((from: number, to: number) => {
+    setStops((prev) => {
+      const next = [...prev]
+      const [moved] = next.splice(from, 1)
+      next.splice(to, 0, moved)
+      return next
+    })
+  }, [])
+
+  const removeStop = useCallback((marketId: string) => {
+    setStops((prev) => prev.filter((s) => s.market.id !== marketId))
+  }, [])
+
+  // --- Optimize ---
+  const optimize = useCallback(async () => {
+    if (stops.length < 2) return
+    setIsOptimizing(true)
+    try {
+      const asStops: Stop[] = stops.map((s) => ({
+        id: s.market.id,
+        lat: s.market.latitude,
+        lng: s.market.longitude,
+      }))
+      const startPoint =
+        !useGps && customStart ? customStart : userPos ? userPos : undefined
+      const optimized = deps.geo.optimizeStops(asStops, startPoint)
+      setStops(
+        optimized.map((opt, i) => ({
+          market: stops.find((s) => s.market.id === opt.id)!.market,
+          index: i,
+        })),
+      )
+    } finally {
+      setIsOptimizing(false)
+    }
+  }, [stops, useGps, customStart, userPos, deps.geo])
+
+  // --- Save (auth) ---
+  const save = useCallback(() => {
+    runSave(name, plannedDate, useGps, customStart, userPos, stops)
+  }, [runSave, name, plannedDate, useGps, customStart, userPos, stops])
+
+  // --- Save (anon) — placeholder; AnonSaveForm handles its own submission ---
+  const saveAnon = useCallback((_email: string) => {
+    // AnonSaveForm manages its own submit flow (fetches route.create-anon endpoint).
+    // This stub exists to satisfy the RouteBuilderState interface so the component
+    // can optionally delegate here in a future refactor.
+  }, [])
+
+  return {
+    name, setName,
+    plannedDate, setPlannedDate,
+    useGps, setUseGps,
+    customStart, setCustomStart,
+    stops, toggleStop, reorderStops, removeStop,
+    optimize, save, saveAnon, clearDraft,
+    markets,
+    isOptimizing, isSaving, saveProgress, gpsError,
+    userPos,
+  }
+}


### PR DESCRIPTION
## Summary

- New \`useRouteBuilder()\` hook in \`web/src/hooks/use-route-builder.ts\` owns all orchestration: markets fetch, draft restore + persist, GPS, telemetry, save mutation.
- Internal sub-hooks under \`web/src/hooks/route-builder/\` split the concerns: \`use-markets-query\`, \`use-draft-persistence\`, \`use-gps-reader\`, \`use-route-save\`, plus \`draft.ts\` for pure storage helpers.
- \`web/src/components/route-builder.tsx\` drops from **369 → 146 LOC** (60% reduction). Now a render-only consumer that threads \`vm.*\` through existing JSX.
- Telemetry preserved exactly: \`route_market_added\`, \`route_save_attempted\`, \`route_saved\`, \`route_save_failed\`, \`route_draft_restored\`, \`route_login_blocked\` (one-shot per session).
- Edit mode is documented as out-of-scope; throws on \`mode === 'edit'\`. YAGNI per the issue.

Closes #78

## Review notes

Opus review caught one production bug in Sonnet's first pass: the geo fallback in \`resolveDeps\` defaulted to an empty stub instead of the real \`@/lib/geo\` import (since \`Deps\` does not yet expose geo). Fixed in this commit; tests now mock \`@/lib/geo\` to avoid pulling Supabase under jsdom.

\`saveAnon\` is exposed on the contract as a documented stub — \`AnonSaveForm\` self-manages its submission today. Wiring it through is a follow-up.

\`StopList\` calls \`onReorder(newStops[])\` while the hook accepts \`(from, to)\`; the component derives the diff. If \`StopList\` ever supports multi-drag, that derivation breaks. Acceptable given the YAGNI mandate; flagged here.

## Test plan

- [x] 21 integration tests for \`useRouteBuilder\` pass locally
- [x] web vitest: 324/324 pass locally (1 pre-existing transform error in \`src/lib/supabase.ts\`, unchanged)
- [x] web tsc --noEmit: clean
- [x] packages/shared: 718/718 pass locally
- [ ] CI: deno-check + check-edge-imports + view-refreshes + test + lighthouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)