### PR TITLE
refactor: remove deprecated LatLng alias, migrate 6 callers to Coord

### DIFF
--- a/packages/shared/src/geo/index.ts
+++ b/packages/shared/src/geo/index.ts
@@ -10,21 +10,12 @@
  *   - `nearbyMarkets(center, radiusKm)` — calls the `nearby_flea_markets` Supabase
  *       RPC; returns published markets within the given radius.
  *   - `optimizeStops(stops, startPoint?)` — thin wrapper over `domain/route-optimizer`.
- *
- * Note: `LatLng` is a deprecated alias for `Coord` kept for back-compat.
- * New code should import `Coord` from '@fyndstigen/shared' directly.
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { FleaMarketNearBy } from '../types'
 import type { Coord } from '../types/domain'
 import { optimizeRoute, type Stop } from '../domain/route-optimizer'
-
-/**
- * @deprecated Use `Coord` from '@fyndstigen/shared' instead.
- * Kept for one release to avoid breaking external imports.
- */
-export type LatLng = Coord
 
 export class GeocodeError extends Error {
   constructor(address: string, cause?: unknown) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -72,7 +72,7 @@ export type { InMemorySubscriptionRepo } from './adapters/in-memory/subscription
 
 // Geo
 export { createGeo, GeocodeError } from './geo'
-export type { LatLng, GeoService, GeoOptions } from './geo'
+export type { GeoService, GeoOptions } from './geo'
 
 // Errors
 export { appError, isAppError, toAppError, messageFor, interpolate } from './errors'

--- a/web/src/hooks/route-builder/use-gps-reader.ts
+++ b/web/src/hooks/route-builder/use-gps-reader.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import type { LatLng } from '@fyndstigen/shared'
+import type { Coord } from '@fyndstigen/shared'
 
 /**
  * Watches the `useGps` flag and fires `getCurrentPosition` only on the
@@ -10,8 +10,8 @@ import type { LatLng } from '@fyndstigen/shared'
 export function useGpsReader(
   useGps: boolean,
   geolocation: Geolocation | undefined,
-): { userPos: LatLng | null; gpsError: string | null } {
-  const [userPos, setUserPos] = useState<LatLng | null>(null)
+): { userPos: Coord | null; gpsError: string | null } {
+  const [userPos, setUserPos] = useState<Coord | null>(null)
   const [gpsError, setGpsError] = useState<string | null>(null)
   const prevUseGpsRef = useRef<boolean | null>(null)
 

--- a/web/src/hooks/route-builder/use-route-save.ts
+++ b/web/src/hooks/route-builder/use-route-save.ts
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { runRouteMutation } from '@fyndstigen/shared'
 import type { RouteEvent } from '@fyndstigen/shared'
-import type { LatLng, AuthUser } from '@fyndstigen/shared'
+import type { Coord, AuthUser } from '@fyndstigen/shared'
 import type { RouteRepository } from '@fyndstigen/shared'
 import type { RouteBuilderStop } from '@/components/route-builder/stop-list'
 
@@ -27,8 +27,8 @@ export function useRouteSave(deps: SaveDeps) {
     name: string,
     plannedDate: string,
     useGps: boolean,
-    customStart: LatLng | null,
-    userPos: LatLng | null,
+    customStart: Coord | null,
+    userPos: Coord | null,
     stops: RouteBuilderStop[],
   ) {
     const { routes, posthog, router, user, onClearDraft } = deps

--- a/web/src/hooks/use-route-builder.ts
+++ b/web/src/hooks/use-route-builder.ts
@@ -6,7 +6,7 @@ import { usePostHog } from 'posthog-js/react'
 import { useDeps } from '@/providers/deps-provider'
 import { useAuth } from '@/lib/auth/auth-context'
 import { geo as defaultGeo } from '@/lib/geo'
-import type { FleaMarketNearBy, GeoService, LatLng, AuthUser } from '@fyndstigen/shared'
+import type { FleaMarketNearBy, GeoService, Coord, AuthUser } from '@fyndstigen/shared'
 import type { RouteRepository } from '@fyndstigen/shared'
 import type { Stop } from '@fyndstigen/shared'
 import type { RouteBuilderStop } from '@/components/route-builder/stop-list'
@@ -42,8 +42,8 @@ export interface RouteBuilderState {
   setPlannedDate: (v: string) => void
   useGps: boolean
   setUseGps: (v: boolean) => void
-  customStart: LatLng | null
-  setCustomStart: (v: LatLng | null) => void
+  customStart: Coord | null
+  setCustomStart: (v: Coord | null) => void
   stops: RouteBuilderStop[]
   toggleStop: (marketId: string) => void
   reorderStops: (from: number, to: number) => void
@@ -58,7 +58,7 @@ export interface RouteBuilderState {
   saveProgress: RouteSaveProgress | null
   gpsError: string | null
   /** GPS-resolved user position (set when useGps=true and permission granted) */
-  userPos: LatLng | null
+  userPos: Coord | null
 }
 
 export interface RouteBuilderOptions {
@@ -114,7 +114,7 @@ export function useRouteBuilder(opts?: RouteBuilderOptions): RouteBuilderState {
   const [name, setName] = useState('')
   const [plannedDate, setPlannedDate] = useState('')
   const [useGps, setUseGps] = useState(true)
-  const [customStart, setCustomStart] = useState<LatLng | null>(null)
+  const [customStart, setCustomStart] = useState<Coord | null>(null)
   const [stops, setStops] = useState<RouteBuilderStop[]>([])
   const [isOptimizing, setIsOptimizing] = useState(false)
 


### PR DESCRIPTION
Closes #106. Mechanical rename across web/src/hooks/route-builder; alias deleted from packages/shared/src/geo/index.ts and barrel.

## Test plan
- [x] packages/shared 735/735, web 372/372, tsc clean
- [ ] CI