### PR TITLE
tooling(check-view-refreshes): auto-discover wildcard views

### DIFF
--- a/scripts/check-view-refreshes.mjs
+++ b/scripts/check-view-refreshes.mjs
@@ -3,18 +3,19 @@
  * check-view-refreshes.mjs
  *
  * Migrations that ALTER a table also need to refresh any view defined as
- * `SELECT t.*` over that table — Postgres freezes the view's column list
- * at creation time, so columns added later don't auto-project. We learned
- * this when slug landed in flea_markets but visible_flea_markets kept
- * returning the pre-slug shape, breaking /loppis/[slug].
+ * `SELECT <alias>.*` over that table — Postgres freezes the view's column
+ * list at creation time, so columns added later don't auto-project. We
+ * learned this when slug landed in flea_markets but visible_flea_markets
+ * kept returning the pre-slug shape, breaking /loppis/[slug].
  *
- * This script scans supabase/migrations/*.sql and fails if any migration
- * touches a table with dependent views without also refreshing each view
- * in the same file.
+ * This script auto-discovers wildcard views from migrations: any
+ * `CREATE [OR REPLACE] VIEW v AS SELECT t.*` (or `SELECT *`) gets registered
+ * and policed. Explicit-column views are exempt — only wildcard views drift.
+ *
+ * The latest definition of each view wins. If a view is later redefined to
+ * use explicit columns, it drops out of the policed set automatically.
  *
  * Run: node scripts/check-view-refreshes.mjs
- *
- * To register a new dependency, add it to TABLE_VIEWS below.
  */
 
 import { readFileSync, readdirSync } from 'node:fs'
@@ -24,36 +25,79 @@ import { fileURLToPath } from 'node:url'
 const repoRoot = join(fileURLToPath(import.meta.url), '..', '..')
 const migrationsDir = join(repoRoot, 'supabase', 'migrations')
 
-/**
- * Map of base tables to views that select * over them. When a migration
- * runs `alter table <key>`, it must also `create or replace view <value>`
- * (one entry per dependent view) so column changes propagate.
- *
- * Add a new entry whenever you create a `select <table>.*` view.
- */
-const TABLE_VIEWS = {
-  flea_markets: ['visible_flea_markets'],
-}
-
 const files = readdirSync(migrationsDir)
   .filter((f) => f.endsWith('.sql'))
   .sort()
 
-// Pre-pass: per view, find the highest-numbered migration that refreshes it.
-// Earlier migrations that altered the underlying table are "absorbed" by
-// that refresh — drift is already healed in DB — so we shouldn't keep
-// flagging them on every push. Only migrations LATER than the refresh need
-// to handle their own column additions.
-const lastRefreshIndex = new Map() // view -> file index
-for (const view of Object.values(TABLE_VIEWS).flat()) {
-  const refreshRe = new RegExp(
-    `create\\s+or\\s+replace\\s+view\\s+(public\\.)?${view}\\b`,
-    'i',
-  )
-  files.forEach((file, idx) => {
+/**
+ * Auto-discover wildcard views.
+ *
+ * Pattern matches:
+ *   create [or replace] view [public.]<view> [with (...)] as
+ *     select <alias>.* from [public.]<table> <alias> ...
+ *
+ * Or the unaliased form:
+ *     select * from [public.]<table> ...
+ *
+ * Returns a map of base-table → Set of dependent views.
+ */
+function discoverWildcardViews() {
+  const viewLatestKind = new Map() // view -> { kind: 'wildcard' | 'explicit', table?: string }
+
+  const viewRe =
+    /create\s+(?:or\s+replace\s+)?view\s+(?:public\.)?(\w+)\b[\s\S]*?\bas\b([\s\S]*?);/gi
+
+  for (const file of files) {
     const src = readFileSync(join(migrationsDir, file), 'utf8').toLowerCase()
-    if (refreshRe.test(src)) lastRefreshIndex.set(view, idx)
-  })
+    viewRe.lastIndex = 0
+    let match
+    while ((match = viewRe.exec(src)) !== null) {
+      const view = match[1]
+      const body = match[2]
+
+      const aliasedWildcard = body.match(
+        /select\s+(\w+)\.\*[\s\S]*?from\s+(?:public\.)?(\w+)\s+\1\b/i,
+      )
+      const bareWildcard = body.match(/select\s+\*\s+from\s+(?:public\.)?(\w+)\b/i)
+
+      if (aliasedWildcard) {
+        viewLatestKind.set(view, { kind: 'wildcard', table: aliasedWildcard[2] })
+      } else if (bareWildcard) {
+        viewLatestKind.set(view, { kind: 'wildcard', table: bareWildcard[1] })
+      } else {
+        viewLatestKind.set(view, { kind: 'explicit' })
+      }
+    }
+  }
+
+  const tableViews = new Map() // table -> Set<view>
+  for (const [view, info] of viewLatestKind) {
+    if (info.kind !== 'wildcard' || !info.table) continue
+    if (!tableViews.has(info.table)) tableViews.set(info.table, new Set())
+    tableViews.get(info.table).add(view)
+  }
+  return tableViews
+}
+
+const TABLE_VIEWS = discoverWildcardViews()
+
+if (TABLE_VIEWS.size === 0) {
+  console.log('check-view-refreshes: no wildcard views found.')
+  process.exit(0)
+}
+
+const lastRefreshIndex = new Map() // view -> file index
+for (const views of TABLE_VIEWS.values()) {
+  for (const view of views) {
+    const refreshRe = new RegExp(
+      `create\\s+(or\\s+replace\\s+)?view\\s+(public\\.)?${view}\\b`,
+      'i',
+    )
+    files.forEach((file, idx) => {
+      const src = readFileSync(join(migrationsDir, file), 'utf8').toLowerCase()
+      if (refreshRe.test(src)) lastRefreshIndex.set(view, idx)
+    })
+  }
 }
 
 let violations = 0
@@ -63,9 +107,7 @@ files.forEach((file, idx) => {
   const src = readFileSync(full, 'utf8').toLowerCase()
   const rel = relative(repoRoot, full).replace(/\\/g, '/')
 
-  for (const [table, views] of Object.entries(TABLE_VIEWS)) {
-    // Match column-shape changes that risk view drift. INSERT/UPDATE/DELETE
-    // don't change shape, so they're fine — only DDL is policed.
+  for (const [table, views] of TABLE_VIEWS) {
     const altersTable = new RegExp(
       `alter\\s+table\\s+(public\\.)?${table}\\b[\\s\\S]*?(add|drop|alter)\\s+column`,
       'i',
@@ -73,24 +115,18 @@ files.forEach((file, idx) => {
     if (!altersTable) continue
 
     for (const view of views) {
-      // Skip migrations covered by a later refresh — that newer migration
-      // re-expanded the view against the schema-of-the-day, so historical
-      // drift is healed and there's nothing to fix here.
       const lastRefresh = lastRefreshIndex.get(view) ?? -1
       if (idx < lastRefresh) continue
 
-      // Same-file refresh is the only signal we accept for current/future
-      // migrations. A later separate migration would in theory work too,
-      // but we want the check to flag drift at the moment it's introduced.
       const refreshes = new RegExp(
-        `create\\s+or\\s+replace\\s+view\\s+(public\\.)?${view}\\b`,
+        `create\\s+(or\\s+replace\\s+)?view\\s+(public\\.)?${view}\\b`,
         'i',
       ).test(src)
       if (!refreshes) {
         console.error(
           `MISSING VIEW REFRESH  ${rel}\n` +
             `  Migration alters ${table} but does not refresh dependent view ${view}.\n` +
-            `  Append:  CREATE OR REPLACE VIEW public.${view} AS SELECT fm.* FROM ...\n` +
+            `  Append:  CREATE OR REPLACE VIEW public.${view} AS SELECT t.* FROM ...\n` +
             `  (Use the original definition — see migration that first created the view.)\n`,
         )
         violations++
@@ -103,5 +139,10 @@ if (violations > 0) {
   console.error(`\ncheck-view-refreshes: ${violations} violation(s) found. Aborting.`)
   process.exit(1)
 } else {
-  console.log(`check-view-refreshes: all migrations OK (${files.length} scanned).`)
+  const summary = Array.from(TABLE_VIEWS.entries())
+    .map(([t, vs]) => `${t} -> ${[...vs].join(',')}`)
+    .join('; ')
+  console.log(
+    `check-view-refreshes: all migrations OK (${files.length} scanned). Tracked: ${summary}.`,
+  )
 }


### PR DESCRIPTION
Closes #112. Replaces hardcoded TABLE_VIEWS with auto-discovery from migration CREATE VIEW statements. Only wildcard views (SELECT t.* or SELECT *) get policed; explicit-column views skip naturally.

Current run: 49 migrations scanned, tracks `flea_markets -> visible_flea_markets` (unchanged from old hardcoded list, but auto-detected now).

Side benefit: new wildcard views land already-checked. Side detection from the audit: `auth_user_email_view` (quirk #10 in ARCHITECTURE.md) is actually present in `00018_admin.sql` — the audit was wrong; closing #108 separately.

## Test plan
- [x] check-view-refreshes runs clean against current migrations
- [ ] CI