### PR TITLE
refactor(types): remove 2 unused snake_case aliases (partial #110)

### DIFF
--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -68,7 +68,6 @@ import type {
   MarketTableRow,
   BookingRow as BookingDbRow,
   RouteRow,
-  StripeAccountRow,
 } from './db'
 import type {
   BookingStatus,
@@ -115,19 +114,11 @@ export type OrganizerStats = {
   total_commission_sek: number
 }
 
-// Stripe
-export type StripeAccount = StripeAccountRow
-
 // Market tables
 export type MarketTable = MarketTableRow
 
 // Bookings
 export type Booking = BookingDbRow
-export type BookingWithDetails = BookingDbRow & {
-  market_table: { label: string; description: string | null; size_description: string | null } | null
-  flea_market: { name: string; city: string } | null
-  booker: { first_name: string | null; last_name: string | null } | null
-}
 
 // Routes
 export type Route = RouteRow


### PR DESCRIPTION
Partial #110.

Two aliases have zero consumers (verified by grep):

- `StripeAccount` — adapters use the row type directly
- `BookingWithDetails` — superseded by `BookingView`

Pure deletion. The remaining 14 aliases have 4-17 consumers each and need full migration including property-access renames (snake_case → camelCase); defer to follow-up PRs.

## Test plan
- [x] packages/shared 735 pass, web tsc clean
- [ ] CI