### PR TITLE
refactor(types): migrate PopularRoute → PopularRouteView (batch 2 of #110)

### DIFF
--- a/packages/shared/src/adapters/in-memory/routes.ts
+++ b/packages/shared/src/adapters/in-memory/routes.ts
@@ -12,7 +12,7 @@ import type {
   UpdateRoutePayload,
   RouteWithStops,
   RouteSummary,
-  PopularRoute,
+  PopularRouteView,
 } from '../../types'
 import type { RouteRepository } from '../../ports/routes'
 
@@ -158,7 +158,7 @@ export function createInMemoryRoutes(seed: StoredRoute[] = []): RouteRepository 
      * Seam tests that call this will get a silent false-negative.
      * Provide real data via seed and a custom implementation if you need to assert against results.
      */
-    async listPopular(_params): Promise<PopularRoute[]> {
+    async listPopular(_params): Promise<PopularRouteView[]> {
       console.warn('[in-memory] listPopular() is a stub and always returns []. Seed the repo if you need results.')
       return []
     },

--- a/packages/shared/src/adapters/supabase/routes.ts
+++ b/packages/shared/src/adapters/supabase/routes.ts
@@ -14,8 +14,34 @@ import type {
   UpdateRoutePayload,
   RouteWithStops,
   RouteSummary,
-  PopularRoute,
+  PopularRouteView,
 } from '../../types'
+
+type PopularRouteRpcRow = {
+  id: string
+  name: string
+  description: string | null
+  created_by: string
+  planned_date: string | null
+  published_at: string | null
+  stop_count: number
+  creator_first_name: string | null
+  creator_last_name: string | null
+}
+
+function mapPopularRoute(r: PopularRouteRpcRow): PopularRouteView {
+  return {
+    id: r.id,
+    name: r.name,
+    description: r.description,
+    createdBy: r.created_by,
+    plannedDate: r.planned_date,
+    publishedAt: r.published_at,
+    stopCount: r.stop_count,
+    creatorFirstName: r.creator_first_name,
+    creatorLastName: r.creator_last_name,
+  }
+}
 import type { RouteDetailsRow, RouteSummaryRow } from '../../api/mappers'
 import type { RouteRepository } from '../../ports/routes'
 import { RouteQuery } from '../../query/route'
@@ -138,7 +164,7 @@ export function createSupabaseRoutes(supabase: SupabaseClient): RouteRepository 
         radius_km: params.radiusKm ?? 30,
       })
       if (error) throw error
-      return (data ?? []) as PopularRoute[]
+      return (data as PopularRouteRpcRow[] ?? []).map(mapPopularRoute)
     },
   }
 }

--- a/packages/shared/src/ports/routes.ts
+++ b/packages/shared/src/ports/routes.ts
@@ -13,7 +13,7 @@ import type {
   UpdateRoutePayload,
   RouteWithStops,
   RouteSummary,
-  PopularRoute,
+  PopularRouteView,
 } from '../types'
 import type { Publishable } from './publishable'
 
@@ -23,5 +23,5 @@ export interface RouteRepository extends Publishable {
   update(id: string, payload: UpdateRoutePayload): Promise<void>
   delete(id: string): Promise<void>
   listByUser(userId: string): Promise<RouteSummary[]>
-  listPopular(params: { latitude: number; longitude: number; radiusKm?: number }): Promise<PopularRoute[]>
+  listPopular(params: { latitude: number; longitude: number; radiusKm?: number }): Promise<PopularRouteView[]>
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -137,18 +137,6 @@ export type RouteWithStops = RouteRow & {
 export type RouteSummary = RouteRow & {
   stopCount: number
 }
-export type PopularRoute = {
-  id: string
-  name: string
-  description: string | null
-  created_by: string
-  planned_date: string | null
-  published_at: string | null
-  stop_count: number
-  creator_first_name: string | null
-  creator_last_name: string | null
-}
-
 // Payloads (these were already camelCase — no aliases needed)
 export type AddressPayload = {
   street: string

--- a/web/src/app/rundor/page.tsx
+++ b/web/src/app/rundor/page.tsx
@@ -62,7 +62,7 @@ export default function RoutesDiscoveryPage() {
         <div className="space-y-3">
           {routes.map((route, i) => {
             const creatorName =
-              [route.creator_first_name, route.creator_last_name]
+              [route.creatorFirstName, route.creatorLastName]
                 .filter(Boolean)
                 .join(' ') || 'Anonym'
 
@@ -101,11 +101,11 @@ export default function RoutesDiscoveryPage() {
                     {route.name}
                   </h3>
                   <div className="flex items-center gap-3 mt-1 text-xs text-espresso/60">
-                    <span>{route.stop_count} stopp</span>
+                    <span>{route.stopCount} stopp</span>
                     <span>Av {creatorName}</span>
-                    {route.planned_date && (
+                    {route.plannedDate && (
                       <span>
-                        {new Date(route.planned_date).toLocaleDateString(
+                        {new Date(route.plannedDate).toLocaleDateString(
                           'sv-SE',
                           { day: 'numeric', month: 'short' },
                         )}

--- a/web/src/hooks/use-routes.ts
+++ b/web/src/hooks/use-routes.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import type { RouteWithStops, RouteSummary, PopularRoute, CreateRoutePayload, UpdateRoutePayload } from '@fyndstigen/shared'
+import type { RouteWithStops, RouteSummary, PopularRouteView, CreateRoutePayload, UpdateRoutePayload } from '@fyndstigen/shared'
 import { queryKeys } from '@/lib/query-keys'
 import { useDeps } from '@/providers/deps-provider'
 
@@ -40,7 +40,7 @@ export function usePopularRoutes(params: { latitude: number; longitude: number; 
     queryFn: () => routes.listPopular(params),
   })
   return {
-    routes: data ?? ([] as PopularRoute[]),
+    routes: data ?? ([] as PopularRouteView[]),
     loading: isLoading,
     error: error?.message ?? null,
   }


### PR DESCRIPTION
Partial #110.

PopularRoute was a 4-caller, self-contained snake_case alias. Migrated end-to-end:

- Port `RouteRepository.listPopular()` now returns `PopularRouteView[]`
- Supabase adapter adds a typed `PopularRouteRpcRow` + `mapPopularRoute()` mapper between the snake_case RPC output and the camelCase view
- In-memory adapter return type updated
- Web caller renames: `creator_first_name` → `creatorFirstName`, `stop_count` → `stopCount`, `planned_date` → `plannedDate`

Earlier audit comment on #110 marked this as Tier C (needs mapper) but it ended up tractable in one PR. The remaining 13 clusters have heavier blockers — port contracts, missing View fields, domain-logic side effects.

## Test plan
- [x] packages/shared 735, web 372, tsc clean
- [ ] CI