### PR TITLE
refactor(types): migrate FleaMarketNearBy → FleaMarketNearByView (batch 3 of #110)

### DIFF
--- a/packages/shared/src/adapters/in-memory/flea-markets.ts
+++ b/packages/shared/src/adapters/in-memory/flea-markets.ts
@@ -16,7 +16,6 @@
 import type {
   FleaMarket,
   FleaMarketDetails,
-  FleaMarketNearBy,
   MarketTable,
   CreateFleaMarketPayload,
   UpdateFleaMarketPayload,
@@ -24,6 +23,7 @@ import type {
   SearchResult,
   OpeningHourRule,
 } from '../../types'
+import type { FleaMarketNearByView } from '../../types/domain'
 import type { FleaMarketRepository, SearchRepository, MarketTableRepository } from '../../ports/flea-markets'
 import type { ProfileRepository } from '../../ports/profiles'
 
@@ -103,7 +103,7 @@ function buildRepo(
      */
     async nearBy(_params) {
       console.warn('[in-memory] nearBy() is a stub and always returns []. Seed the repo if you need results.')
-      return [] as FleaMarketNearBy[]
+      return [] as FleaMarketNearByView[]
     },
 
     async create(payload) {

--- a/packages/shared/src/adapters/supabase/flea-markets.ts
+++ b/packages/shared/src/adapters/supabase/flea-markets.ts
@@ -14,15 +14,43 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import type {
   FleaMarket,
   FleaMarketDetails,
-  FleaMarketNearBy,
   MarketTable,
   CreateFleaMarketPayload,
   UpdateFleaMarketPayload,
   CreateMarketTablePayload,
   SearchResult,
 } from '../../types'
+import type { FleaMarketNearByView } from '../../types/domain'
 import { FleaMarketQuery, type FleaMarketDetailsRow } from '../../query/flea-market'
 import type { FleaMarketRepository, SearchRepository, MarketTableRepository, WeekendOpenSlot } from '../../ports/flea-markets'
+
+type NearbyFleaMarketRpcRow = {
+  id: string
+  name: string
+  description: string
+  city: string
+  is_permanent: boolean
+  latitude: number
+  longitude: number
+  distance_km: number
+  published_at: string | null
+  slug?: string | null
+}
+
+function mapNearbyFleaMarket(r: NearbyFleaMarketRpcRow): FleaMarketNearByView {
+  return {
+    id: r.id,
+    name: r.name,
+    description: r.description,
+    city: r.city,
+    isPermanent: r.is_permanent,
+    latitude: r.latitude,
+    longitude: r.longitude,
+    distanceKm: r.distance_km,
+    publishedAt: r.published_at,
+    slug: r.slug ?? null,
+  }
+}
 
 export function createSupabaseFleaMarkets(supabase: SupabaseClient): FleaMarketRepository {
   return {
@@ -60,7 +88,7 @@ export function createSupabaseFleaMarkets(supabase: SupabaseClient): FleaMarketR
         radius_km: params.radiusKm,
       })
       if (error) throw error
-      return data as FleaMarketNearBy[]
+      return (data as NearbyFleaMarketRpcRow[] ?? []).map(mapNearbyFleaMarket)
     },
 
     async create(payload) {

--- a/packages/shared/src/geo/geo.test.ts
+++ b/packages/shared/src/geo/geo.test.ts
@@ -58,8 +58,24 @@ describe('createGeo', () => {
   })
 
   describe('nearbyMarkets', () => {
-    it('calls supabase rpc with correct params', async () => {
-      mockSupabase.rpc.mockResolvedValue({ data: [{ id: 'm1' }], error: null })
+    it('calls supabase rpc and maps snake_case rows to camelCase view', async () => {
+      mockSupabase.rpc.mockResolvedValue({
+        data: [
+          {
+            id: 'm1',
+            name: 'Stortorget',
+            description: '',
+            city: 'Stockholm',
+            is_permanent: true,
+            latitude: 59.3,
+            longitude: 18.0,
+            distance_km: 0.5,
+            published_at: '2024-01-01T00:00:00Z',
+            slug: 'stortorget',
+          },
+        ],
+        error: null,
+      })
 
       const geo = createGeo(mockSupabase)
       const result = await geo.nearbyMarkets({ lat: 59.0, lng: 18.0 }, 30)
@@ -69,7 +85,20 @@ describe('createGeo', () => {
         lng: 18.0,
         radius_km: 30,
       })
-      expect(result).toEqual([{ id: 'm1' }])
+      expect(result).toEqual([
+        {
+          id: 'm1',
+          name: 'Stortorget',
+          description: '',
+          city: 'Stockholm',
+          isPermanent: true,
+          latitude: 59.3,
+          longitude: 18.0,
+          distanceKm: 0.5,
+          publishedAt: '2024-01-01T00:00:00Z',
+          slug: 'stortorget',
+        },
+      ])
     })
   })
 

--- a/packages/shared/src/geo/index.ts
+++ b/packages/shared/src/geo/index.ts
@@ -13,9 +13,36 @@
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { FleaMarketNearBy } from '../types'
-import type { Coord } from '../types/domain'
+import type { Coord, FleaMarketNearByView } from '../types/domain'
 import { optimizeRoute, type Stop } from '../domain/route-optimizer'
+
+type NearbyFleaMarketRpcRow = {
+  id: string
+  name: string
+  description: string
+  city: string
+  is_permanent: boolean
+  latitude: number
+  longitude: number
+  distance_km: number
+  published_at: string | null
+  slug?: string | null
+}
+
+function mapNearbyFleaMarket(r: NearbyFleaMarketRpcRow): FleaMarketNearByView {
+  return {
+    id: r.id,
+    name: r.name,
+    description: r.description,
+    city: r.city,
+    isPermanent: r.is_permanent,
+    latitude: r.latitude,
+    longitude: r.longitude,
+    distanceKm: r.distance_km,
+    publishedAt: r.published_at,
+    slug: r.slug ?? null,
+  }
+}
 
 export class GeocodeError extends Error {
   constructor(address: string, cause?: unknown) {
@@ -36,7 +63,7 @@ export type GeoService = {
   /** Geocode a free-text address to coordinates. Throws GeocodeError on failure. */
   geocode(address: string): Promise<Coord>
   /** Find published flea markets within radiusKm of a point. */
-  nearbyMarkets(center: Coord, radiusKm: number): Promise<FleaMarketNearBy[]>
+  nearbyMarkets(center: Coord, radiusKm: number): Promise<FleaMarketNearByView[]>
   /** Reorder stops for shortest path (nearest-neighbor). */
   optimizeStops<T extends Stop>(stops: T[], startPoint?: Coord): T[]
 }
@@ -67,14 +94,14 @@ export function createGeo(supabase: SupabaseClient, options?: GeoOptions): GeoSe
       }
     },
 
-    async nearbyMarkets(center: Coord, radiusKm: number): Promise<FleaMarketNearBy[]> {
+    async nearbyMarkets(center: Coord, radiusKm: number): Promise<FleaMarketNearByView[]> {
       const { data, error } = await supabase.rpc('nearby_flea_markets', {
         lat: center.lat,
         lng: center.lng,
         radius_km: radiusKm,
       })
       if (error) throw error
-      return data as FleaMarketNearBy[]
+      return (data as NearbyFleaMarketRpcRow[] ?? []).map(mapNearbyFleaMarket)
     },
 
     optimizeStops<T extends Stop>(stops: T[], startPoint?: Coord): T[] {

--- a/packages/shared/src/ports/flea-markets.ts
+++ b/packages/shared/src/ports/flea-markets.ts
@@ -17,13 +17,13 @@
 import type {
   FleaMarket,
   FleaMarketDetails,
-  FleaMarketNearBy,
   MarketTable,
   CreateFleaMarketPayload,
   UpdateFleaMarketPayload,
   CreateMarketTablePayload,
   SearchResult,
 } from '../types'
+import type { FleaMarketNearByView } from '../types/domain'
 import type { Publishable } from './publishable'
 
 export type WeekendOpenSlot = {
@@ -41,7 +41,7 @@ export type WeekendOpenSlot = {
 export interface FleaMarketRepository extends Publishable {
   list(params?: { page?: number; pageSize?: number }): Promise<{ items: FleaMarket[]; count: number }>
   details(id: string): Promise<FleaMarketDetails>
-  nearBy(params: { latitude: number; longitude: number; radiusKm: number }): Promise<FleaMarketNearBy[]>
+  nearBy(params: { latitude: number; longitude: number; radiusKm: number }): Promise<FleaMarketNearByView[]>
   create(payload: CreateFleaMarketPayload): Promise<{ id: string }>
   update(id: string, payload: UpdateFleaMarketPayload): Promise<void>
   delete(id: string): Promise<void>

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -56,6 +56,7 @@ export type FleaMarketNearByView = {
   longitude: number
   distanceKm: number
   publishedAt: string | null
+  slug?: string | null
 }
 
 // --- Opening Hours ---

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -83,19 +83,6 @@ export type FleaMarketDetails = FleaMarketRow & {
   opening_hour_exceptions: OpeningHourExceptionRow[]
   flea_market_images: FleaMarketImageRow[]
 }
-export type FleaMarketNearBy = {
-  id: string
-  name: string
-  description: string
-  city: string
-  is_permanent: boolean
-  latitude: number
-  longitude: number
-  distance_km: number
-  published_at: string | null
-  slug?: string | null
-}
-
 // Opening hours (unchanged shapes)
 export type OpeningHourRule = OpeningHourRuleRow & { type: RuleType }
 export type OpeningHourException = OpeningHourExceptionRow

--- a/web/src/app/utforska/page.tsx
+++ b/web/src/app/utforska/page.tsx
@@ -61,7 +61,7 @@ export default function ExplorePage() {
     name: string
     city: string | null
     description: string | null
-    is_permanent: boolean
+    isPermanent: boolean
     latitude: number | null
     longitude: number | null
     slug?: string | null
@@ -69,12 +69,12 @@ export default function ExplorePage() {
   const allMarkets: CardMarket[] = useNearby
     ? nearby.markets.map((m) => ({
         id: m.id, name: m.name, city: m.city, description: m.description,
-        is_permanent: m.is_permanent, latitude: m.latitude, longitude: m.longitude,
+        isPermanent: m.isPermanent, latitude: m.latitude, longitude: m.longitude,
         slug: m.slug,
       }))
     : fallback.markets.map((m) => ({
         id: m.id, name: m.name, city: m.city, description: m.description,
-        is_permanent: m.is_permanent, latitude: m.latitude, longitude: m.longitude,
+        isPermanent: m.is_permanent, latitude: m.latitude, longitude: m.longitude,
         slug: m.slug,
       }))
   const totalCount = useNearby ? nearby.markets.length : fallback.count
@@ -338,10 +338,10 @@ export default function ExplorePage() {
                   <div className="absolute top-2.5 right-2.5">
                     <span
                       className={`stamp text-[10px] ${
-                        market.is_permanent ? 'text-forest' : 'text-mustard'
+                        market.isPermanent ? 'text-forest' : 'text-mustard'
                       }`}
                     >
-                      {market.is_permanent ? 'Permanent' : 'Tillfällig'}
+                      {market.isPermanent ? 'Permanent' : 'Tillfällig'}
                     </span>
                   </div>
                 </div>

--- a/web/src/components/map-view.tsx
+++ b/web/src/components/map-view.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from 'next/navigation'
 import { useMap } from 'react-leaflet'
 import { geo } from '@/lib/geo'
 import { supabase } from '@/lib/supabase'
-import type { FleaMarketNearBy } from '@fyndstigen/shared'
+import type { FleaMarketNearByView } from '@fyndstigen/shared'
 import { marketUrl } from '@/lib/urls'
 import { FyndstigenLogo } from './fyndstigen-logo'
 import { FyndstigenMap, type MapMarker } from './fyndstigen-map'
@@ -44,7 +44,7 @@ export default function MapView() {
   const targetName = params.get('name')
   const targetSlug = params.get('slug')
 
-  const [markets, setMarkets] = useState<FleaMarketNearBy[]>([])
+  const [markets, setMarkets] = useState<FleaMarketNearByView[]>([])
   const [blockSales, setBlockSales] = useState<BlockSalePin[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/web/src/components/route-builder/route-builder.tsx
+++ b/web/src/components/route-builder/route-builder.tsx
@@ -9,10 +9,10 @@ import { StopList, type RouteBuilderStop } from './stop-list'
 import { RouteMap } from './route-map'
 import { SaveRouteButton } from './save-route-button'
 import { AnonSaveForm } from './anon-save-form'
-import type { FleaMarketNearBy } from '@fyndstigen/shared'
+import type { FleaMarketNearByView } from '@fyndstigen/shared'
 import type { OpeningHourRule, OpeningHourException } from '@fyndstigen/shared'
 
-type MarketWithHours = FleaMarketNearBy & {
+type MarketWithHours = FleaMarketNearByView & {
   opening_hour_rules?: OpeningHourRule[]
   opening_hour_exceptions?: OpeningHourException[]
 }

--- a/web/src/components/route-builder/route-map.tsx
+++ b/web/src/components/route-builder/route-map.tsx
@@ -10,11 +10,11 @@
  */
 
 import { useMapEvents } from 'react-leaflet'
-import type { FleaMarketNearBy } from '@fyndstigen/shared'
+import type { FleaMarketNearByView } from '@fyndstigen/shared'
 import type { OpeningHourRule, OpeningHourException } from '@fyndstigen/shared'
 import { FyndstigenMap, type MapMarker } from '../fyndstigen-map'
 
-type MarketWithHours = FleaMarketNearBy & {
+type MarketWithHours = FleaMarketNearByView & {
   opening_hour_rules?: OpeningHourRule[]
   opening_hour_exceptions?: OpeningHourException[]
 }

--- a/web/src/components/route-builder/stop-list.tsx
+++ b/web/src/components/route-builder/stop-list.tsx
@@ -3,9 +3,9 @@
 import { useState } from 'react'
 import { checkOpeningHours, type OpeningHourRule, type OpeningHourException } from '@fyndstigen/shared'
 import { FyndstigenLogo } from '../fyndstigen-logo'
-import type { FleaMarketNearBy } from '@fyndstigen/shared'
+import type { FleaMarketNearByView } from '@fyndstigen/shared'
 
-type MarketWithHours = FleaMarketNearBy & {
+type MarketWithHours = FleaMarketNearByView & {
   opening_hour_rules?: OpeningHourRule[]
   opening_hour_exceptions?: OpeningHourException[]
 }

--- a/web/src/hooks/route-builder/use-draft-persistence.ts
+++ b/web/src/hooks/route-builder/use-draft-persistence.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import type { FleaMarketNearBy } from '@fyndstigen/shared'
+import type { FleaMarketNearByView } from '@fyndstigen/shared'
 import type { RouteBuilderStop } from '@/components/route-builder/stop-list'
 import { readDraft, writeDraft, clearDraft as clearDraftFn, DRAFT_KEY } from './draft'
 import type { RouteDraft } from './draft'
@@ -20,7 +20,7 @@ type DraftState = {
 }
 
 export function useDraftPersistence(
-  markets: FleaMarketNearBy[] | undefined,
+  markets: FleaMarketNearByView[] | undefined,
   state: DraftState,
   setName: (v: string) => void,
   setPlannedDate: (v: string) => void,

--- a/web/src/hooks/route-builder/use-markets-query.ts
+++ b/web/src/hooks/route-builder/use-markets-query.ts
@@ -1,14 +1,14 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import type { FleaMarketNearBy, GeoService } from '@fyndstigen/shared'
+import type { FleaMarketNearByView, GeoService } from '@fyndstigen/shared'
 
 // Sweden center — national radius. The route builder filters client-side.
 const SWEDEN_CENTER = { lat: 59.27, lng: 15.21 }
 const RADIUS_KM = 2000
 
 export function useMarketsQuery(geo: GeoService) {
-  const { data } = useQuery<FleaMarketNearBy[]>({
+  const { data } = useQuery<FleaMarketNearByView[]>({
     queryKey: ['route-builder', 'markets'],
     queryFn: () => geo.nearbyMarkets(SWEDEN_CENTER, RADIUS_KM),
     staleTime: Infinity,

--- a/web/src/hooks/use-route-builder.test.tsx
+++ b/web/src/hooks/use-route-builder.test.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { useRouteBuilder } from './use-route-builder'
 import type { RouteBuilderDeps } from './use-route-builder'
-import type { FleaMarketNearBy, GeoService } from '@fyndstigen/shared'
+import type { FleaMarketNearByView, GeoService } from '@fyndstigen/shared'
 
 // ---------------------------------------------------------------------------
 // Mock next/navigation — must be hoisted
@@ -61,28 +61,28 @@ vi.mock('@/lib/geo', () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-const SEED_MARKET: FleaMarketNearBy = {
+const SEED_MARKET: FleaMarketNearByView = {
   id: 'm1',
   name: 'Loppis A',
   description: '',
   city: 'Testköping',
-  is_permanent: false,
+  isPermanent: false,
   latitude: 59.3,
   longitude: 18.0,
-  distance_km: 1,
-  published_at: '2024-01-01T00:00:00Z',
+  distanceKm: 1,
+  publishedAt: '2024-01-01T00:00:00Z',
 }
 
-const SEED_MARKET_2: FleaMarketNearBy = {
+const SEED_MARKET_2: FleaMarketNearByView = {
   id: 'm2',
   name: 'Loppis B',
   description: '',
   city: 'Testköping',
-  is_permanent: false,
+  isPermanent: false,
   latitude: 59.4,
   longitude: 18.1,
-  distance_km: 2,
-  published_at: '2024-01-01T00:00:00Z',
+  distanceKm: 2,
+  publishedAt: '2024-01-01T00:00:00Z',
 }
 
 function makeStorage(): Storage & { _data: Map<string, string> } {

--- a/web/src/hooks/use-route-builder.ts
+++ b/web/src/hooks/use-route-builder.ts
@@ -6,7 +6,7 @@ import { usePostHog } from 'posthog-js/react'
 import { useDeps } from '@/providers/deps-provider'
 import { useAuth } from '@/lib/auth/auth-context'
 import { geo as defaultGeo } from '@/lib/geo'
-import type { FleaMarketNearBy, GeoService, Coord, AuthUser } from '@fyndstigen/shared'
+import type { FleaMarketNearByView, GeoService, Coord, AuthUser } from '@fyndstigen/shared'
 import type { RouteRepository } from '@fyndstigen/shared'
 import type { Stop } from '@fyndstigen/shared'
 import type { RouteBuilderStop } from '@/components/route-builder/stop-list'
@@ -52,7 +52,7 @@ export interface RouteBuilderState {
   save: () => void
   saveAnon: (email: string) => void
   clearDraft: () => void
-  markets: FleaMarketNearBy[] | undefined
+  markets: FleaMarketNearByView[] | undefined
   isOptimizing: boolean
   isSaving: boolean
   saveProgress: RouteSaveProgress | null


### PR DESCRIPTION
Partial #110.

Migrated FleaMarketNearBy (12 callers + 2 RPC producers).

- `FleaMarketNearByView` gains `slug?` (RPC returned it since 00048)
- `geo.nearbyMarkets()` and `FleaMarketRepository.nearBy()` map snake_case RPC rows to camelCase view (mapper duplicated; extract on third caller)
- All 12 web callers renamed
- `utforska/page.tsx` CardMarket adapter switched to camelCase; bridge for the snake_case fallback source
- Test fixtures updated

Local `MarketWithHours` type extensions keep snake_case `opening_hour_rules` for now — defers to OpeningHourRule migration (Tier C in audit; field is never populated in practice).

## Test plan
- [x] packages/shared 735, web 372, tsc clean
- [ ] CI