### PR TITLE
refactor(types): migrate FleaMarketImage → FleaMarketImageView (batch 5 of #110)

### DIFF
--- a/packages/shared/src/adapters/in-memory/images.ts
+++ b/packages/shared/src/adapters/in-memory/images.ts
@@ -1,4 +1,4 @@
-import type { FleaMarketImage } from '../../types'
+import type { FleaMarketImageView } from '../../types'
 import type { ImagePort } from '../../ports/images'
 
 /**
@@ -13,7 +13,7 @@ import type { ImagePort } from '../../ports/images'
  * to assert that the port was called with the right arguments.
  */
 export function createInMemoryImages(): ImagePort {
-  const store = new Map<string, FleaMarketImage>()
+  const store = new Map<string, FleaMarketImageView>()
   let _id = 1
 
   return {
@@ -21,20 +21,20 @@ export function createInMemoryImages(): ImagePort {
       return `https://in-memory/${storagePath}`
     },
 
-    async add(marketId: string, file: File): Promise<FleaMarketImage> {
+    async add(marketId: string, file: File): Promise<FleaMarketImageView> {
       const ext = file.name.split('.').pop()?.toLowerCase() || 'jpg'
       const storagePath = `${marketId}/in-memory-${_id}.${ext}`
-      const row: FleaMarketImage = {
+      const view: FleaMarketImageView = {
         id: `img-${_id++}`,
-        storage_path: storagePath,
-        sort_order: store.size,
+        storagePath,
+        sortOrder: store.size,
       }
-      store.set(storagePath, row)
-      return { ...row }
+      store.set(storagePath, view)
+      return { ...view }
     },
 
-    async remove(image: FleaMarketImage): Promise<void> {
-      store.delete(image.storage_path)
+    async remove(image: FleaMarketImageView): Promise<void> {
+      store.delete(image.storagePath)
     },
   }
 }

--- a/packages/shared/src/adapters/supabase/images.ts
+++ b/packages/shared/src/adapters/supabase/images.ts
@@ -14,7 +14,7 @@
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { FleaMarketImage } from '../../types'
+import type { FleaMarketImageView } from '../../types'
 import type { ImagePort } from '../../ports/images'
 
 const BUCKET = 'flea-market-images'
@@ -39,7 +39,7 @@ export function createSupabaseImages(deps: SupabaseImageAdapterDeps): ImagePort 
       return data.publicUrl
     },
 
-    async add(marketId: string, file: File): Promise<FleaMarketImage> {
+    async add(marketId: string, file: File): Promise<FleaMarketImageView> {
       const toUpload = compress ? await compress(file) : file
       const ext = toUpload.name.split('.').pop()?.toLowerCase() || 'jpg'
       const path = `${marketId}/${crypto.randomUUID()}.${ext}`
@@ -75,12 +75,12 @@ export function createSupabaseImages(deps: SupabaseImageAdapterDeps): ImagePort 
       const row = Array.isArray(data) ? data[0] : data
       return {
         id: row.id,
-        storage_path: row.storage_path,
-        sort_order: row.sort_order,
+        storagePath: row.storage_path,
+        sortOrder: row.sort_order,
       }
     },
 
-    async remove(image: FleaMarketImage): Promise<void> {
+    async remove(image: FleaMarketImageView): Promise<void> {
       // DB-first: delete the row before touching storage. If the DB delete
       // fails the blob is still intact — safe failure with no broken image.
       const { error } = await supabase
@@ -93,9 +93,9 @@ export function createSupabaseImages(deps: SupabaseImageAdapterDeps): ImagePort 
       // (source of truth is correct) and the orphaned blob can be swept later.
       const { error: storageErr } = await supabase.storage
         .from(BUCKET)
-        .remove([image.storage_path])
+        .remove([image.storagePath])
       if (storageErr) {
-        console.warn('[SupabaseImages] orphaned storage blob:', image.storage_path, storageErr)
+        console.warn('[SupabaseImages] orphaned storage blob:', image.storagePath, storageErr)
       }
     },
   }

--- a/packages/shared/src/api/images.test.ts
+++ b/packages/shared/src/api/images.test.ts
@@ -94,20 +94,20 @@ function fakeFile(name = 'photo.jpg', size = 100): File {
 }
 
 describe('createImageService', () => {
-  it('happy path: uploads blob and inserts row with computed path and sort_order', async () => {
+  it('happy path: uploads blob and inserts row with computed path and sortOrder', async () => {
     const stub = createStubSupabase()
     const svc = createImageService({ supabase: stub.supabase })
 
     const result = await svc.add('market-1', fakeFile('beach.jpg'))
 
-    expect(result.sort_order).toBe(0)
-    expect(result.storage_path).toMatch(/^market-1\/[0-9a-f-]+\.jpg$/)
+    expect(result.sortOrder).toBe(0)
+    expect(result.storagePath).toMatch(/^market-1\/[0-9a-f-]+\.jpg$/)
     expect(stub.spies.uploadSpy).toHaveBeenCalledTimes(1)
     expect(stub.spies.rpcSpy).toHaveBeenCalledWith('insert_flea_market_image', {
       p_flea_market_id: 'market-1',
-      p_storage_path: result.storage_path,
+      p_storage_path: result.storagePath,
     })
-    expect(stub.uploads.has(result.storage_path)).toBe(true)
+    expect(stub.uploads.has(result.storagePath)).toBe(true)
   })
 
   it('orphan rescue: when INSERT rejects, the uploaded blob is removed', async () => {
@@ -121,15 +121,15 @@ describe('createImageService', () => {
     expect(stub.spies.removeSpy).toHaveBeenCalledWith([uploadedPath])
   })
 
-  it('sort_order assignment: two sequential adds get 0 then 1 via the RPC', async () => {
+  it('sortOrder assignment: two sequential adds get 0 then 1 via the RPC', async () => {
     const stub = createStubSupabase()
     const svc = createImageService({ supabase: stub.supabase })
 
     const first = await svc.add('market-1', fakeFile('a.jpg'))
     const second = await svc.add('market-1', fakeFile('b.jpg'))
 
-    expect(first.sort_order).toBe(0)
-    expect(second.sort_order).toBe(1)
+    expect(first.sortOrder).toBe(0)
+    expect(second.sortOrder).toBe(1)
     // Both went through the atomic RPC — not a read-then-write.
     expect(stub.spies.rpcSpy).toHaveBeenCalledTimes(2)
     for (const call of stub.spies.rpcSpy.mock.calls) {
@@ -167,9 +167,9 @@ describe('createImageService', () => {
 
       // Both deleted
       expect(stub.spies.deleteSpy).toHaveBeenCalledWith(created.id)
-      expect(stub.spies.removeSpy).toHaveBeenCalledWith([created.storage_path])
+      expect(stub.spies.removeSpy).toHaveBeenCalledWith([created.storagePath])
       expect(stub.rows).toHaveLength(0)
-      expect(stub.uploads.has(created.storage_path)).toBe(false)
+      expect(stub.uploads.has(created.storagePath)).toBe(false)
 
       // DB delete must have been called before storage remove
       const deleteOrder = stub.spies.deleteSpy.mock.invocationCallOrder[0]
@@ -191,7 +191,7 @@ describe('createImageService', () => {
       // Storage must not have been touched
       expect(stub.spies.removeSpy).not.toHaveBeenCalled()
       // The blob is still in storage
-      expect(stub.uploads.has(created.storage_path)).toBe(true)
+      expect(stub.uploads.has(created.storagePath)).toBe(true)
     })
 
     it('storage remove fails: DB row is deleted, no throw, warning is logged', async () => {
@@ -213,7 +213,7 @@ describe('createImageService', () => {
       // Warning was logged with expected marker and path
       expect(warnSpy).toHaveBeenCalledWith(
         '[ImageService] orphaned storage blob:',
-        created.storage_path,
+        created.storagePath,
         storageError,
       )
     })

--- a/packages/shared/src/api/images.ts
+++ b/packages/shared/src/api/images.ts
@@ -1,11 +1,11 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { FleaMarketImage } from '../types'
+import type { FleaMarketImageView } from '../types'
 
 const BUCKET = 'flea-market-images'
 
 export type ImageService = {
-  add(marketId: string, file: File): Promise<FleaMarketImage>
-  remove(image: FleaMarketImage): Promise<void>
+  add(marketId: string, file: File): Promise<FleaMarketImageView>
+  remove(image: FleaMarketImageView): Promise<void>
   publicUrl(storagePath: string): string
 }
 
@@ -24,7 +24,7 @@ export function createImageService(deps: ImageServiceDeps): ImageService {
   const { supabase, compress } = deps
 
   return {
-    async add(marketId: string, file: File): Promise<FleaMarketImage> {
+    async add(marketId: string, file: File): Promise<FleaMarketImageView> {
       const toUpload = compress ? await compress(file) : file
       const ext = toUpload.name.split('.').pop()?.toLowerCase() || 'jpg'
       const path = `${marketId}/${crypto.randomUUID()}.${ext}`
@@ -60,12 +60,12 @@ export function createImageService(deps: ImageServiceDeps): ImageService {
       const row = Array.isArray(data) ? data[0] : data
       return {
         id: row.id,
-        storage_path: row.storage_path,
-        sort_order: row.sort_order,
+        storagePath: row.storage_path,
+        sortOrder: row.sort_order,
       }
     },
 
-    async remove(image: FleaMarketImage): Promise<void> {
+    async remove(image: FleaMarketImageView): Promise<void> {
       // DB-first: delete the row before touching storage. If the DB delete
       // fails the blob is still intact — safe failure with no broken image.
       const { error } = await supabase
@@ -78,9 +78,9 @@ export function createImageService(deps: ImageServiceDeps): ImageService {
       // (source of truth is correct) and the orphaned blob can be swept later.
       const { error: storageErr } = await supabase.storage
         .from(BUCKET)
-        .remove([image.storage_path])
+        .remove([image.storagePath])
       if (storageErr) {
-        console.warn('[ImageService] orphaned storage blob:', image.storage_path, storageErr)
+        console.warn('[ImageService] orphaned storage blob:', image.storagePath, storageErr)
       }
     },
 

--- a/packages/shared/src/domain/market-mutation.test.ts
+++ b/packages/shared/src/domain/market-mutation.test.ts
@@ -29,7 +29,7 @@ function makeMarketTables(overrides: Partial<TablesDeps> = {}): TablesDeps {
 
 function makeImages(overrides: Partial<ImagesDeps> = {}): ImagesDeps {
   return {
-    add: vi.fn().mockResolvedValue({ id: 'img-1', storage_path: 'p/1.jpg', sort_order: 0 }),
+    add: vi.fn().mockResolvedValue({ id: 'img-1', storagePath: 'p/1.jpg', sortOrder: 0 }),
     remove: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   }
@@ -172,7 +172,7 @@ describe('runMarketMutation — failures', () => {
     const addMock = vi
       .fn()
       .mockRejectedValueOnce(new Error('Storage error'))
-      .mockResolvedValueOnce({ id: 'img-2', storage_path: 'p/2.jpg', sort_order: 1 })
+      .mockResolvedValueOnce({ id: 'img-2', storagePath: 'p/2.jpg', sortOrder: 1 })
     const deps = makeDeps({
       images: { add: addMock, remove: vi.fn().mockResolvedValue(undefined) },
     })
@@ -240,7 +240,7 @@ describe('runMarketMutation — edit existing market', () => {
     },
     images: {
       add: [makeFile('new.jpg')],
-      remove: [{ id: 'old-img', storage_path: 'p/old.jpg', sort_order: 0 }],
+      remove: [{ id: 'old-img', storagePath: 'p/old.jpg', sortOrder: 0 }],
     },
     tables: {
       add: [{ label: 'N', description: '', priceSek: 50, sizeDescription: '' }],

--- a/packages/shared/src/domain/market-mutation.ts
+++ b/packages/shared/src/domain/market-mutation.ts
@@ -16,7 +16,7 @@ import type {
   CreateFleaMarketPayload,
   UpdateFleaMarketPayload,
   CreateMarketTablePayload,
-  FleaMarketImage,
+  FleaMarketImageView,
 } from '../types'
 import type { FleaMarketRepository, MarketTableRepository } from '../ports/flea-markets'
 import type { ImagePort } from '../ports/images'
@@ -95,7 +95,7 @@ export type MarketPlan = {
   market:
     | { create: MarketCreateFields }
     | { update: { id: string; patch: MarketUpdateFields } }
-  images: { add: File[]; remove: FleaMarketImage[] }
+  images: { add: File[]; remove: FleaMarketImageView[] }
   tables: { add: MarketPlanTableDraft[]; remove: string[] }
   opening: { rules: MarketPlanRuleDraft[]; exceptions: MarketPlanExceptionDraft[] }
 }

--- a/packages/shared/src/ports/images.ts
+++ b/packages/shared/src/ports/images.ts
@@ -1,4 +1,4 @@
-import type { FleaMarketImage } from '../types'
+import type { FleaMarketImageView } from '../types'
 
 /**
  * Port for flea-market image storage operations.
@@ -18,13 +18,13 @@ export type ImagePort = {
 
   /**
    * Upload a File to the market's image folder, then persist the row via RPC.
-   * Returns the inserted `flea_market_images` row.
+   * Returns the inserted `flea_market_images` row as a camelCase view.
    */
-  add(marketId: string, file: File): Promise<FleaMarketImage>
+  add(marketId: string, file: File): Promise<FleaMarketImageView>
 
   /**
    * Delete the DB row and best-effort remove the storage object.
    * DB deletion is authoritative; storage failure is logged but not thrown.
    */
-  remove(image: FleaMarketImage): Promise<void>
+  remove(image: FleaMarketImageView): Promise<void>
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -84,9 +84,6 @@ export type FleaMarketDetails = FleaMarketRow & {
   flea_market_images: FleaMarketImageRow[]
 }
 
-// Images
-export type FleaMarketImage = FleaMarketImageRow
-
 // Profiles
 export type UserProfile = ProfileRow
 export type OrganizerProfile = OrganizerProfileRow

--- a/web/src/app/fleamarkets/[id]/edit/page.tsx
+++ b/web/src/app/fleamarkets/[id]/edit/page.tsx
@@ -168,7 +168,7 @@ export default function EditMarketPage() {
                   key={img.id}
                   className={`relative aspect-square rounded-lg overflow-hidden bg-cream-warm group ${isDeleted ? 'opacity-30' : ''}`}
                 >
-                  <Image src={imagePort.publicUrl(img.storage_path)} alt="" fill sizes="96px" className="object-cover" />
+                  <Image src={imagePort.publicUrl(img.storagePath)} alt="" fill sizes="96px" className="object-cover" />
                   {isDeleted ? (
                     <button
                       type="button"

--- a/web/src/components/market/image-gallery.tsx
+++ b/web/src/components/market/image-gallery.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import Image from 'next/image'
-import type { FleaMarketImage } from '@fyndstigen/shared'
+import type { FleaMarketImageView } from '@fyndstigen/shared'
 import { useDeps } from '@/providers/deps-provider'
 
 type Props = {
-  images: FleaMarketImage[]
+  images: FleaMarketImageView[]
   marketName: string
 }
 
@@ -33,7 +33,7 @@ export function MarketImageGallery({ images, marketName }: Props) {
             }`}
           >
             <Image
-              src={imagesPort.publicUrl(img.storage_path)}
+              src={imagesPort.publicUrl(img.storagePath)}
               alt={marketName}
               fill
               sizes={single ? '100vw' : '(min-width: 640px) 33vw, 50vw'}

--- a/web/src/hooks/market-form/use-image-draft.test.ts
+++ b/web/src/hooks/market-form/use-image-draft.test.ts
@@ -1,13 +1,13 @@
 import { renderHook, act } from '@testing-library/react'
 import { useImageDraft } from './use-image-draft'
-import type { FleaMarketImage } from '@fyndstigen/shared'
+import type { FleaMarketImageView } from '@fyndstigen/shared'
 
 // jsdom doesn't implement createObjectURL
 global.URL.createObjectURL = vi.fn((f: File) => `blob:${f.name}`)
 global.URL.revokeObjectURL = vi.fn()
 
-const img1: FleaMarketImage = { id: 'img-1', storage_path: 'a/1.jpg', sort_order: 0 }
-const img2: FleaMarketImage = { id: 'img-2', storage_path: 'a/2.jpg', sort_order: 1 }
+const img1: FleaMarketImageView = { id: 'img-1', storagePath: 'a/1.jpg', sortOrder: 0 }
+const img2: FleaMarketImageView = { id: 'img-2', storagePath: 'a/2.jpg', sortOrder: 1 }
 
 function makeFile(name: string) {
   return new File(['x'], name, { type: 'image/jpeg' })
@@ -28,7 +28,7 @@ describe('useImageDraft', () => {
   })
 
   it('addFiles respects MAX_IMAGES = 6 cap', () => {
-    const existing = Array.from({ length: 5 }, (_, i) => ({ ...img1, id: `img-${i}`, sort_order: i }))
+    const existing = Array.from({ length: 5 }, (_, i) => ({ ...img1, id: `img-${i}`, sortOrder: i }))
     const { result } = renderHook(() => useImageDraft(existing))
     act(() => result.current.addFiles([makeFile('x.jpg'), makeFile('y.jpg')]))
     expect(result.current.newFiles).toHaveLength(1)

--- a/web/src/hooks/market-form/use-image-draft.ts
+++ b/web/src/hooks/market-form/use-image-draft.ts
@@ -1,12 +1,12 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import type { FleaMarketImage } from '@fyndstigen/shared'
+import type { FleaMarketImageView } from '@fyndstigen/shared'
 
-export type ImageDraftExisting = FleaMarketImage & { _deleted?: boolean }
+export type ImageDraftExisting = FleaMarketImageView & { _deleted?: boolean }
 
 export type ImageDraftResult = {
-  /** Existing images from DB, sorted by sort_order */
+  /** Existing images from DB, sorted by sortOrder */
   existingImages: ImageDraftExisting[]
   /** Newly selected files (not yet uploaded) */
   newFiles: File[]
@@ -18,19 +18,19 @@ export type ImageDraftResult = {
   removeExisting: (id: string) => void
   undoRemoveExisting: (id: string) => void
   removeNew: (index: number) => void
-  reset: (images: FleaMarketImage[]) => void
+  reset: (images: FleaMarketImageView[]) => void
   resetNew: () => void
   serialize: () => {
     add: File[]
-    remove: { id: string; storage_path: string; sort_order: number }[]
+    remove: FleaMarketImageView[]
   }
 }
 
 const MAX_IMAGES = 6
 
-export function useImageDraft(initialImages: FleaMarketImage[] = []): ImageDraftResult {
+export function useImageDraft(initialImages: FleaMarketImageView[] = []): ImageDraftResult {
   const [existingImages, setExistingImages] = useState<ImageDraftExisting[]>(
-    () => [...initialImages].sort((a, b) => a.sort_order - b.sort_order),
+    () => [...initialImages].sort((a, b) => a.sortOrder - b.sortOrder),
   )
   const [newFiles, setNewFiles] = useState<File[]>([])
   const [newPreviews, setNewPreviews] = useState<string[]>([])
@@ -82,8 +82,8 @@ export function useImageDraft(initialImages: FleaMarketImage[] = []): ImageDraft
     })
   }, [])
 
-  const reset = useCallback((images: FleaMarketImage[]) => {
-    setExistingImages([...images].sort((a, b) => a.sort_order - b.sort_order))
+  const reset = useCallback((images: FleaMarketImageView[]) => {
+    setExistingImages([...images].sort((a, b) => a.sortOrder - b.sortOrder))
     setNewFiles([])
     setNewPreviews((prev) => {
       prev.forEach(URL.revokeObjectURL)
@@ -115,7 +115,7 @@ export function useImageDraft(initialImages: FleaMarketImage[] = []): ImageDraft
       add: newFiles,
       remove: existingImages
         .filter((img) => img._deleted)
-        .map((img) => ({ id: img.id, storage_path: img.storage_path, sort_order: img.sort_order })),
+        .map((img) => ({ id: img.id, storagePath: img.storagePath, sortOrder: img.sortOrder })),
     }),
     [newFiles, existingImages],
   )

--- a/web/src/hooks/market-form/use-market-form.test.ts
+++ b/web/src/hooks/market-form/use-market-form.test.ts
@@ -36,7 +36,7 @@ describe('useMarketForm — create mode', () => {
     vi.spyOn(testDeps.markets, 'update').mockResolvedValue(undefined)
     vi.spyOn(testDeps.marketTables, 'create').mockResolvedValue({ id: 'table-1' })
     vi.spyOn(testDeps.marketTables, 'delete').mockResolvedValue(undefined)
-    vi.spyOn(testDeps.images, 'add').mockResolvedValue({ id: 'img-1', storage_path: 'p/1.jpg', sort_order: 0 })
+    vi.spyOn(testDeps.images, 'add').mockResolvedValue({ id: 'img-1', storagePath: 'p/1.jpg', sortOrder: 0 })
     vi.spyOn(testDeps.images, 'remove').mockResolvedValue(undefined)
   })
 
@@ -114,7 +114,7 @@ describe('useMarketForm — edit mode', () => {
     vi.spyOn(testDeps.markets, 'update').mockResolvedValue(undefined)
     vi.spyOn(testDeps.marketTables, 'create').mockResolvedValue({ id: 'table-1' })
     vi.spyOn(testDeps.marketTables, 'delete').mockResolvedValue(undefined)
-    vi.spyOn(testDeps.images, 'add').mockResolvedValue({ id: 'img-1', storage_path: 'p/1.jpg', sort_order: 0 })
+    vi.spyOn(testDeps.images, 'add').mockResolvedValue({ id: 'img-1', storagePath: 'p/1.jpg', sortOrder: 0 })
     vi.spyOn(testDeps.images, 'remove').mockResolvedValue(undefined)
   })
 

--- a/web/src/hooks/market-form/use-market-form.ts
+++ b/web/src/hooks/market-form/use-market-form.ts
@@ -39,7 +39,13 @@ export function useMarketForm({ mode, initial, organizerId }: UseMarketFormOptio
     })) ?? [],
   )
 
-  const images = useImageDraft(initial?.flea_market_images ?? [])
+  const images = useImageDraft(
+    (initial?.flea_market_images ?? []).map((img) => ({
+      id: img.id,
+      storagePath: img.storage_path,
+      sortOrder: img.sort_order,
+    })),
+  )
 
   const tables = useTableDraft(initial?.market_tables ?? [])
 
@@ -77,7 +83,13 @@ export function useMarketForm({ mode, initial, organizerId }: UseMarketFormOptio
         reason: ex.reason,
       })) ?? [],
     )
-    images.reset(initial.flea_market_images ?? [])
+    images.reset(
+      (initial.flea_market_images ?? []).map((img) => ({
+        id: img.id,
+        storagePath: img.storage_path,
+        sortOrder: img.sort_order,
+      })),
+    )
     tables.reset(initial.market_tables ?? [])
   }, [initial, fields, openingHours, images, tables])
 

--- a/web/src/hooks/use-market-detail-view-model.ts
+++ b/web/src/hooks/use-market-detail-view-model.ts
@@ -3,7 +3,7 @@
 import { useMemo } from 'react'
 import type {
   FleaMarketDetails,
-  FleaMarketImage,
+  FleaMarketImageView,
   MarketTable,
   OpeningHourRuleView,
   OpeningHourExceptionView,
@@ -15,8 +15,8 @@ import { useMarketDetails } from './use-market-details'
 export type MarketDetailViewModel = {
   market: FleaMarketDetails | null
   tables: MarketTable[]
-  /** Sorted by sort_order ascending. Empty array if the market has no images. */
-  images: FleaMarketImage[]
+  /** Sorted by sortOrder ascending. Empty array if the market has no images. */
+  images: FleaMarketImageView[]
   /** Undefined when the market has neither rules nor exceptions. */
   openingHours: { rules: OpeningHourRuleView[]; exceptions: OpeningHourExceptionView[] } | undefined
   isOwner: boolean
@@ -35,9 +35,9 @@ export function useMarketDetailViewModel(id: string): MarketDetailViewModel {
   const { market, tables, loading, error } = useMarketDetails(id)
 
   return useMemo<MarketDetailViewModel>(() => {
-    const images = [...(market?.flea_market_images ?? [])].sort(
-      (a, b) => a.sort_order - b.sort_order,
-    )
+    const images: FleaMarketImageView[] = [...(market?.flea_market_images ?? [])]
+      .sort((a, b) => a.sort_order - b.sort_order)
+      .map((img) => ({ id: img.id, storagePath: img.storage_path, sortOrder: img.sort_order }))
 
     const rules: OpeningHourRuleView[] = (market?.opening_hour_rules ?? []).map((r) => ({
       id: r.id,


### PR DESCRIPTION
Partial #110.

Port-contract change: `ImagePort.add()` and `ImagePort.remove()` now use `FleaMarketImageView` (camelCase `storagePath`, `sortOrder`) instead of the snake_case alias.

15 files. Adapters map snake_case rows to View at the boundary; web consumers get clean camelCase.

`FleaMarketDetails.flea_market_images: FleaMarketImageRow[]` stays snake_case (Tier C). Row → View conversion happens at view-model boundaries (`use-market-detail-view-model.ts`, `use-market-form.ts`) until FleaMarketDetails migrates.

## Test plan
- [x] packages/shared 735, web 372, tsc clean, edge-imports clean
- [ ] CI