### PR TITLE
refactor(types): migrate UserProfile + OrganizerProfile → *View (batch 6 of #110)

### DIFF
--- a/mobile/lib/api.ts
+++ b/mobile/lib/api.ts
@@ -14,7 +14,7 @@ export type {
   RouteWithStops,
   RouteSummary,
   PopularRoute,
-  OrganizerProfile,
+  OrganizerProfileView as OrganizerProfile,
   OrganizerStats,
-  UserProfile,
+  UserProfileView as UserProfile,
 } from '@fyndstigen/shared'

--- a/packages/shared/src/adapters/in-memory/flea-markets.ts
+++ b/packages/shared/src/adapters/in-memory/flea-markets.ts
@@ -81,7 +81,7 @@ function buildRepo(
       if (deps?.profiles) {
         try {
           const profile = await deps.profiles.get(m.organizer_id)
-          organizerName = [profile.first_name, profile.last_name].filter(Boolean).join(' ')
+          organizerName = [profile.firstName, profile.lastName].filter(Boolean).join(' ')
         } catch {
           // Profile not found — leave empty
         }

--- a/packages/shared/src/adapters/in-memory/profiles.test.ts
+++ b/packages/shared/src/adapters/in-memory/profiles.test.ts
@@ -1,45 +1,45 @@
 import { describe, it, expect } from 'vitest'
 import { createInMemoryProfiles, createInMemoryOrganizers } from './profiles'
-import type { UserProfile, OrganizerProfile } from '../../types'
+import type { UserProfileView, OrganizerProfileView } from '../../types'
 
-function makeProfile(overrides: Partial<UserProfile> = {}): UserProfile {
+function makeProfile(overrides: Partial<UserProfileView> = {}): UserProfileView {
   return {
     id: 'user-1',
-    first_name: 'Anna',
-    last_name: 'Andersson',
-    phone_number: null,
-    user_type: 0,
+    firstName: 'Anna',
+    lastName: 'Andersson',
+    phoneNumber: null,
+    userType: 0,
     ...overrides,
-  } as UserProfile
+  }
 }
 
-function makeOrganizerProfile(overrides: Partial<OrganizerProfile> = {}): OrganizerProfile {
+function makeOrganizerProfile(overrides: Partial<OrganizerProfileView> = {}): OrganizerProfileView {
   return {
     id: 'org-1',
-    first_name: 'Bo',
-    last_name: 'Bergström',
-    phone_number: null,
-    user_type: 1,
+    firstName: 'Bo',
+    lastName: 'Bergström',
+    phoneNumber: null,
+    userType: 1,
     bio: null,
     website: null,
-    logo_path: null,
-    subscription_tier: 0,
+    logoPath: null,
+    subscriptionTier: 0,
     ...overrides,
-  } as OrganizerProfile
+  }
 }
 
 describe('createInMemoryProfiles', () => {
   it('get returns seeded profile', async () => {
     const repo = createInMemoryProfiles([makeProfile()])
     const p = await repo.get('user-1')
-    expect(p.first_name).toBe('Anna')
+    expect(p.firstName).toBe('Anna')
   })
 
   it('update modifies the profile', async () => {
     const repo = createInMemoryProfiles([makeProfile()])
-    await repo.update('user-1', { first_name: 'Britta' })
+    await repo.update('user-1', { firstName: 'Britta' })
     const p = await repo.get('user-1')
-    expect(p.first_name).toBe('Britta')
+    expect(p.firstName).toBe('Britta')
   })
 
   it('get throws for unknown user', async () => {
@@ -52,7 +52,7 @@ describe('createInMemoryOrganizers', () => {
   it('get returns seeded organizer', async () => {
     const repo = createInMemoryOrganizers([makeOrganizerProfile()])
     const o = await repo.get('org-1')
-    expect(o.first_name).toBe('Bo')
+    expect(o.firstName).toBe('Bo')
   })
 
   it('stats returns zeros for unknown organizer', async () => {

--- a/packages/shared/src/adapters/in-memory/profiles.ts
+++ b/packages/shared/src/adapters/in-memory/profiles.ts
@@ -7,21 +7,21 @@
  * that need specific organizer stat values.
  */
 
-import type { UserProfile, OrganizerProfile, OrganizerStats } from '../../types'
+import type { UserProfileView, OrganizerProfileView, OrganizerStats } from '../../types'
 import type { ProfileRepository, OrganizerRepository } from '../../ports/profiles'
 
-export function createInMemoryProfiles(seed: UserProfile[] = []): ProfileRepository {
-  const store = new Map<string, UserProfile>(seed.map((p) => [p.id, { ...p }]))
+export function createInMemoryProfiles(seed: UserProfileView[] = []): ProfileRepository {
+  const store = new Map<string, UserProfileView>(seed.map((p) => [p.id, { ...p }]))
 
   return {
-    async get(userId: string): Promise<UserProfile> {
+    async get(userId: string): Promise<UserProfileView> {
       const p = store.get(userId)
       // eslint-disable-next-line no-restricted-syntax -- in-memory test double: missing ID is a test-setup error, not a user-facing error
       if (!p) throw new Error(`Profile ${userId} not found`)
       return { ...p }
     },
 
-    async update(userId: string, updates: Partial<UserProfile>): Promise<void> {
+    async update(userId: string, updates: Partial<UserProfileView>): Promise<void> {
       const existing = store.get(userId)
       // eslint-disable-next-line no-restricted-syntax -- in-memory test double: missing ID is a test-setup error, not a user-facing error
       if (!existing) throw new Error(`Profile ${userId} not found`)
@@ -30,12 +30,12 @@ export function createInMemoryProfiles(seed: UserProfile[] = []): ProfileReposit
   }
 }
 
-export function createInMemoryOrganizers(seed: OrganizerProfile[] = []): OrganizerRepository {
-  const profileStore = new Map<string, OrganizerProfile>(seed.map((p) => [p.id, { ...p }]))
+export function createInMemoryOrganizers(seed: OrganizerProfileView[] = []): OrganizerRepository {
+  const profileStore = new Map<string, OrganizerProfileView>(seed.map((p) => [p.id, { ...p }]))
   const statsStore = new Map<string, OrganizerStats>()
 
   return {
-    async get(userId: string): Promise<OrganizerProfile> {
+    async get(userId: string): Promise<OrganizerProfileView> {
       const p = profileStore.get(userId)
       // eslint-disable-next-line no-restricted-syntax -- in-memory test double: missing ID is a test-setup error, not a user-facing error
       if (!p) throw new Error(`OrganizerProfile ${userId} not found`)

--- a/packages/shared/src/adapters/in-memory/stack.test.ts
+++ b/packages/shared/src/adapters/in-memory/stack.test.ts
@@ -12,7 +12,7 @@ import { createInMemoryRoutes } from './routes'
 import { createInMemoryProfiles } from './profiles'
 import { createInMemoryBookings } from './bookings'
 import { createInMemoryStack } from '../in-memory'
-import type { FleaMarket, UserProfile } from '../../types'
+import type { FleaMarket, UserProfileView } from '../../types'
 
 // ---------- helpers ----------
 
@@ -38,15 +38,15 @@ function makeMarket(overrides: Partial<FleaMarket & { is_deleted: boolean }> = {
   } as FleaMarket & { is_deleted: boolean }
 }
 
-function makeProfile(overrides: Partial<UserProfile> = {}): UserProfile {
+function makeProfile(overrides: Partial<UserProfileView> = {}): UserProfileView {
   return {
     id: 'org-1',
-    first_name: 'Karin',
-    last_name: 'Karlsson',
-    phone_number: null,
-    user_type: 1,
+    firstName: 'Karin',
+    lastName: 'Karlsson',
+    phoneNumber: null,
+    userType: 1,
     ...overrides,
-  } as UserProfile
+  }
 }
 
 // ---------- 1. stub canaries ----------
@@ -197,14 +197,14 @@ describe('createInMemoryStack', () => {
     const stack = createInMemoryStack()
 
     // Seed a profile
-    await stack.profiles.update('user-organizer', { first_name: 'Eva', last_name: 'Eriksson' })
+    await stack.profiles.update('user-organizer', { firstName: 'Eva', lastName: 'Eriksson' })
       .catch(async () => {
         // update throws if not found — create via a workaround: we can only seed at construction.
         // Use the stack's fleaMarkets create + a profiles repo seeded separately.
       })
 
     // createInMemoryStack creates an empty profiles repo. Seed it by building a separate stack:
-    const profiles = createInMemoryProfiles([makeProfile({ id: 'org-42', first_name: 'Lars', last_name: 'Lindgren' })])
+    const profiles = createInMemoryProfiles([makeProfile({ id: 'org-42', firstName: 'Lars', lastName: 'Lindgren' })])
     const fleaMarkets = createInMemoryFleaMarkets(
       [makeMarket({ id: 'fm-42', organizer_id: 'org-42' })],
       { profiles },

--- a/packages/shared/src/adapters/supabase/profiles.ts
+++ b/packages/shared/src/adapters/supabase/profiles.ts
@@ -9,8 +9,33 @@
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { UserProfile, OrganizerProfile, OrganizerStats } from '../../types'
+import type { UserProfileView, OrganizerProfileView, OrganizerStats } from '../../types'
+import type { ProfileRow, OrganizerProfileRow } from '../../types/db'
 import type { ProfileRepository, OrganizerRepository } from '../../ports/profiles'
+
+function rowToUserProfileView(row: ProfileRow): UserProfileView {
+  return {
+    id: row.id,
+    firstName: row.first_name,
+    lastName: row.last_name,
+    phoneNumber: row.phone_number,
+    userType: row.user_type,
+  }
+}
+
+function rowToOrganizerProfileView(row: OrganizerProfileRow): OrganizerProfileView {
+  return {
+    id: row.id,
+    firstName: row.first_name,
+    lastName: row.last_name,
+    phoneNumber: row.phone_number,
+    userType: row.user_type,
+    bio: row.bio,
+    website: row.website,
+    logoPath: row.logo_path,
+    subscriptionTier: row.subscription_tier,
+  }
+}
 
 export function createSupabaseProfiles(supabase: SupabaseClient): ProfileRepository {
   return {
@@ -21,13 +46,18 @@ export function createSupabaseProfiles(supabase: SupabaseClient): ProfileReposit
         .eq('id', userId)
         .single()
       if (error) throw error
-      return data as UserProfile
+      return rowToUserProfileView(data as ProfileRow)
     },
 
     async update(userId, updates) {
+      const row: Partial<ProfileRow> = {}
+      if ('firstName' in updates) row.first_name = updates.firstName
+      if ('lastName' in updates) row.last_name = updates.lastName
+      if ('phoneNumber' in updates) row.phone_number = updates.phoneNumber
+      if ('userType' in updates) row.user_type = updates.userType
       const { error } = await supabase
         .from('profiles')
-        .update(updates)
+        .update(row)
         .eq('id', userId)
       if (error) throw error
     },
@@ -43,13 +73,19 @@ export function createSupabaseOrganizers(supabase: SupabaseClient): OrganizerRep
         .eq('id', userId)
         .single()
       if (error) throw error
-      return data as OrganizerProfile
+      return rowToOrganizerProfileView(data as OrganizerProfileRow)
     },
 
     async update(userId, updates) {
+      const row: Partial<OrganizerProfileRow> = {}
+      if ('firstName' in updates) row.first_name = updates.firstName
+      if ('lastName' in updates) row.last_name = updates.lastName
+      if ('phoneNumber' in updates) row.phone_number = updates.phoneNumber
+      if ('bio' in updates) row.bio = updates.bio
+      if ('website' in updates) row.website = updates.website
       const { error } = await supabase
         .from('profiles')
-        .update(updates)
+        .update(row)
         .eq('id', userId)
       if (error) throw error
     },

--- a/packages/shared/src/deps-factory.test.ts
+++ b/packages/shared/src/deps-factory.test.ts
@@ -95,16 +95,16 @@ describe('makeInMemoryDeps', () => {
   })
 
   it('profiles.get returns seeded profile', async () => {
-    const seedProfile = {
+    const seedProfile: import('./types').UserProfileView = {
       id: 'u1',
-      first_name: 'Anna',
-      last_name: 'Svensson',
-      phone_number: null,
-      user_type: 0,
-    } as import('./types').UserProfile
+      firstName: 'Anna',
+      lastName: 'Svensson',
+      phoneNumber: null,
+      userType: 0,
+    }
     const deps = makeInMemoryDeps([], [], [seedProfile])
     const profile = await deps.profiles.get('u1')
-    expect(profile.first_name).toBe('Anna')
+    expect(profile.firstName).toBe('Anna')
   })
 
 })

--- a/packages/shared/src/deps-factory.ts
+++ b/packages/shared/src/deps-factory.ts
@@ -18,7 +18,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Deps } from './deps'
-import type { FleaMarket, UserProfile } from './types'
+import type { FleaMarket, UserProfileView } from './types'
 import type { OpeningHourRuleView } from './types/domain'
 import type { StoredRoute } from './adapters/in-memory/routes'
 import {
@@ -61,7 +61,7 @@ export type { StoredRoute }
 export function makeInMemoryDeps(
   seed: StoredMarket[] = [],
   routes: StoredRoute[] = [],
-  profiles: UserProfile[] = [],
+  profiles: UserProfileView[] = [],
 ): Deps {
   const fleaMarkets = createInMemoryFleaMarkets(seed)
   const marketTables = createInMemoryMarketTables()

--- a/packages/shared/src/ports/profiles.ts
+++ b/packages/shared/src/ports/profiles.ts
@@ -8,18 +8,18 @@
  * Implementations: adapters/supabase/profiles.ts, adapters/in-memory/profiles.ts.
  */
 
-import type { UserProfile, OrganizerProfile, OrganizerStats } from '../types'
+import type { UserProfileView, OrganizerProfileView, OrganizerStats } from '../types'
 
 export interface ProfileRepository {
-  get(userId: string): Promise<UserProfile>
-  update(userId: string, updates: Partial<UserProfile>): Promise<void>
+  get(userId: string): Promise<UserProfileView>
+  update(userId: string, updates: Partial<UserProfileView>): Promise<void>
 }
 
 export interface OrganizerRepository {
-  get(userId: string): Promise<OrganizerProfile>
+  get(userId: string): Promise<OrganizerProfileView>
   update(
     userId: string,
-    updates: Partial<Pick<OrganizerProfile, 'bio' | 'website' | 'first_name' | 'last_name' | 'phone_number'>>,
+    updates: Partial<Pick<OrganizerProfileView, 'bio' | 'website' | 'firstName' | 'lastName' | 'phoneNumber'>>,
   ): Promise<void>
   stats(userId: string): Promise<OrganizerStats>
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -63,8 +63,6 @@ import type {
   OpeningHourRuleRow,
   OpeningHourExceptionRow,
   FleaMarketImageRow,
-  ProfileRow,
-  OrganizerProfileRow,
   MarketTableRow,
   BookingRow as BookingDbRow,
   RouteRow,
@@ -85,8 +83,6 @@ export type FleaMarketDetails = FleaMarketRow & {
 }
 
 // Profiles
-export type UserProfile = ProfileRow
-export type OrganizerProfile = OrganizerProfileRow
 export type OrganizerStats = {
   organizer_id: string
   market_count: number

--- a/web/src/app/arrangorer/[id]/page.test.tsx
+++ b/web/src/app/arrangorer/[id]/page.test.tsx
@@ -15,13 +15,13 @@ import { useAuth } from '@/lib/auth/auth-context'
 
 const mockOrganizer = {
   id: 'org-1',
-  first_name: 'Lisa',
-  last_name: 'Borg',
+  firstName: 'Lisa',
+  lastName: 'Borg',
   bio: 'Loppisälskare',
   website: 'https://lisas-loppisar.se',
-  phone_number: null,
-  logo_path: null,
-  subscription_tier: 1,
+  phoneNumber: null,
+  logoPath: null,
+  subscriptionTier: 1,
 }
 
 const mockMarkets = [
@@ -96,7 +96,7 @@ describe('OrganizerProfilePage', () => {
   })
 
   it('shows Premium badge for premium organizer', async () => {
-    setupMocks({ organizer: { ...mockOrganizer, subscription_tier: 1 } })
+    setupMocks({ organizer: { ...mockOrganizer, subscriptionTier: 1 } })
     render(<OrganizerProfilePage />)
     await waitFor(() => {
       expect(screen.getByText('Premium')).toBeInTheDocument()
@@ -104,7 +104,7 @@ describe('OrganizerProfilePage', () => {
   })
 
   it('hides Premium badge for free organizer', async () => {
-    setupMocks({ organizer: { ...mockOrganizer, subscription_tier: 0 } })
+    setupMocks({ organizer: { ...mockOrganizer, subscriptionTier: 0 } })
     render(<OrganizerProfilePage />)
     await waitFor(() => {
       expect(screen.queryByText('Premium')).not.toBeInTheDocument()

--- a/web/src/app/arrangorer/[id]/page.tsx
+++ b/web/src/app/arrangorer/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
-import type { OrganizerProfile, FleaMarket } from '@fyndstigen/shared'
+import type { OrganizerProfileView, FleaMarket } from '@fyndstigen/shared'
 import { FyndstigenLogo } from '@/components/fyndstigen-logo'
 import { useAuth } from '@/lib/auth/auth-context'
 import { useDeps } from '@/providers/deps-provider'
@@ -13,7 +13,7 @@ export default function OrganizerProfilePage() {
   const { id } = useParams<{ id: string }>()
   const { user } = useAuth()
   const { organizers, markets: marketsRepo } = useDeps()
-  const [organizer, setOrganizer] = useState<OrganizerProfile | null>(null)
+  const [organizer, setOrganizer] = useState<OrganizerProfileView | null>(null)
   const [markets, setMarkets] = useState<FleaMarket[]>([])
   const [loading, setLoading] = useState(true)
 
@@ -53,9 +53,9 @@ export default function OrganizerProfilePage() {
   }
 
   const name =
-    [organizer.first_name, organizer.last_name].filter(Boolean).join(' ') ||
+    [organizer.firstName, organizer.lastName].filter(Boolean).join(' ') ||
     'Arrangör'
-  const isPremium = organizer.subscription_tier >= 1
+  const isPremium = organizer.subscriptionTier >= 1
 
   return (
     <div className="max-w-3xl mx-auto px-6 py-10">

--- a/web/src/app/arrangorer/[id]/statistik/page.test.tsx
+++ b/web/src/app/arrangorer/[id]/statistik/page.test.tsx
@@ -138,7 +138,7 @@ function setupMocks({
   if (tierReject) {
     mockOrganizerGet.mockRejectedValue(new Error('Network error'))
   } else {
-    mockOrganizerGet.mockResolvedValue({ subscription_tier: subscriptionTier } as any)
+    mockOrganizerGet.mockResolvedValue({ subscriptionTier } as any)
   }
 }
 

--- a/web/src/app/arrangorer/[id]/statistik/page.tsx
+++ b/web/src/app/arrangorer/[id]/statistik/page.tsx
@@ -68,7 +68,7 @@ export default function OrganizerStatsPage() {
     }
     if (!id) return
     organizers.get(id)
-      .then((org) => setIsPremium((org?.subscription_tier ?? 0) >= 1))
+      .then((org) => setIsPremium((org?.subscriptionTier ?? 0) >= 1))
       .catch(() => setIsPremium(false))
       .finally(() => setTierLoading(false))
   }, [id, skyltfonstretEnabled])

--- a/web/src/app/profile/edit/page.test.tsx
+++ b/web/src/app/profile/edit/page.test.tsx
@@ -61,16 +61,16 @@ import { endpoints } from '@/lib/edge/edge'
 
 const freeProfile = {
   id: 'user-1',
-  first_name: 'Anna',
-  last_name: 'Svensson',
-  phone_number: null,
+  firstName: 'Anna',
+  lastName: 'Svensson',
+  phoneNumber: null,
   bio: null,
   website: null,
-  logo_path: null,
-  subscription_tier: 0,
+  logoPath: null,
+  subscriptionTier: 0,
 }
 
-const premiumProfile = { ...freeProfile, subscription_tier: 1 }
+const premiumProfile = { ...freeProfile, subscriptionTier: 1 }
 
 const mockUser = { id: 'user-1', email: 'anna@test.se' }
 

--- a/web/src/app/profile/edit/page.tsx
+++ b/web/src/app/profile/edit/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import type { OrganizerProfile } from '@fyndstigen/shared'
+import type { OrganizerProfileView } from '@fyndstigen/shared'
 import { endpoints } from '@/lib/edge/edge'
 import { useAuth } from '@/lib/auth/auth-context'
 import { useDeps } from '@/providers/deps-provider'
@@ -28,7 +28,7 @@ function EditProfilePageInner() {
   const { user, loading: authLoading } = useAuth()
   const { organizers } = useDeps()
   const skyltfonstretEnabled = useFlag('skyltfonstret')
-  const [profile, setProfile] = useState<OrganizerProfile | null>(null)
+  const [profile, setProfile] = useState<OrganizerProfileView | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -83,11 +83,11 @@ function EditProfilePageInner() {
       .get(user.id)
       .then((p) => {
         setProfile(p)
-        setFirstName(p.first_name ?? '')
-        setLastName(p.last_name ?? '')
+        setFirstName(p.firstName ?? '')
+        setLastName(p.lastName ?? '')
         setBio(p.bio ?? '')
         setWebsite(p.website ?? '')
-        setPhone(p.phone_number ?? '')
+        setPhone(p.phoneNumber ?? '')
       })
       .catch(() => {})
       .finally(() => setLoading(false))
@@ -101,11 +101,11 @@ function EditProfilePageInner() {
     setSaveError('')
     try {
       await organizers.update(user.id, {
-        first_name: firstName || null,
-        last_name: lastName || null,
+        firstName: firstName || null,
+        lastName: lastName || null,
         bio: bio || null,
         website: website || null,
-        phone_number: phone || null,
+        phoneNumber: phone || null,
       })
       setSaved(true)
       setTimeout(() => setSaved(false), 3000)
@@ -124,7 +124,7 @@ function EditProfilePageInner() {
     )
   }
 
-  const isPremium = (profile?.subscription_tier ?? 0) >= 1
+  const isPremium = (profile?.subscriptionTier ?? 0) >= 1
 
   return (
     <div className="max-w-2xl mx-auto px-6 py-10">

--- a/web/src/hooks/use-organizers.ts
+++ b/web/src/hooks/use-organizers.ts
@@ -1,14 +1,14 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import type { OrganizerProfile, OrganizerStats } from '@fyndstigen/shared'
+import type { OrganizerProfileView, OrganizerStats } from '@fyndstigen/shared'
 import { useDeps } from '@/providers/deps-provider'
 import { isAppError, messageFor } from '@fyndstigen/shared'
 
 // ─── useOrganizer ──────────────────────────────────────────────────────────
 
 export type UseOrganizerResult = {
-  organizer: OrganizerProfile | null
+  organizer: OrganizerProfileView | null
   loading: boolean
   error: string | null
 }
@@ -19,7 +19,7 @@ export type UseOrganizerResult = {
  */
 export function useOrganizer(id: string | undefined): UseOrganizerResult {
   const { organizers } = useDeps()
-  const [organizer, setOrganizer] = useState<OrganizerProfile | null>(null)
+  const [organizer, setOrganizer] = useState<OrganizerProfileView | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -85,7 +85,7 @@ export function useOrganizerSimpleStats(userId: string | undefined): UseOrganize
 // ─── useUpdateOrganizer ────────────────────────────────────────────────────
 
 export type OrganizerUpdateFields = Partial<
-  Pick<OrganizerProfile, 'bio' | 'website' | 'first_name' | 'last_name' | 'phone_number'>
+  Pick<OrganizerProfileView, 'bio' | 'website' | 'firstName' | 'lastName' | 'phoneNumber'>
 >
 
 export type UseUpdateOrganizerResult = {


### PR DESCRIPTION
Partial #110.

Both profile aliases migrated together. 17 files. The OrganizerRepository.update() port contract Pick keys flipped from snake_case to camelCase; Supabase adapter handles read mapping and write splitting at the boundary.

mobile/lib/api.ts gets back-compat re-exports (mobile is not in CI per #91; this avoids silently breaking that codepath).

## Test plan
- [x] packages/shared 735, web 372, tsc clean, edge-imports clean
- [ ] CI