### PR TITLE
refactor(types): migrate MarketTable → MarketTableView (batch 7 of #110)

### DIFF
--- a/packages/shared/src/adapters/in-memory/flea-markets.test.ts
+++ b/packages/shared/src/adapters/in-memory/flea-markets.test.ts
@@ -233,6 +233,6 @@ describe('createInMemoryMarketTables', () => {
     await repo.create({ fleaMarketId: 'fm-2', label: 'Bord B', priceSek: 150 })
     const result = await repo.list('fm-1')
     expect(result).toHaveLength(1)
-    expect(result[0].flea_market_id).toBe('fm-1')
+    expect(result[0].fleaMarketId).toBe('fm-1')
   })
 })

--- a/packages/shared/src/adapters/in-memory/flea-markets.ts
+++ b/packages/shared/src/adapters/in-memory/flea-markets.ts
@@ -16,13 +16,12 @@
 import type {
   FleaMarket,
   FleaMarketDetails,
-  MarketTable,
   CreateFleaMarketPayload,
   UpdateFleaMarketPayload,
   CreateMarketTablePayload,
   SearchResult,
 } from '../../types'
-import type { FleaMarketNearByView, OpeningHourRuleView } from '../../types/domain'
+import type { FleaMarketNearByView, MarketTableView, OpeningHourRuleView } from '../../types/domain'
 import type { FleaMarketRepository, SearchRepository, MarketTableRepository } from '../../ports/flea-markets'
 import type { ProfileRepository } from '../../ports/profiles'
 
@@ -273,30 +272,30 @@ export function createInMemorySearch(
   }
 }
 
-export function createInMemoryMarketTables(seed: MarketTable[] = []): MarketTableRepository {
-  const store = new Map<string, MarketTable>(seed.map((t) => [t.id, { ...t }]))
+export function createInMemoryMarketTables(seed: MarketTableView[] = []): MarketTableRepository {
+  const store = new Map<string, MarketTableView>(seed.map((t) => [t.id, { ...t }]))
   let _tid = 1
 
   return {
     async list(fleaMarketId) {
       return Array.from(store.values()).filter(
-        (t) => t.flea_market_id === fleaMarketId && t.is_available,
+        (t) => t.fleaMarketId === fleaMarketId && t.isAvailable,
       )
     },
 
     async create(payload) {
       const id = `mt-${_tid++}`
-      const table: MarketTable = {
+      const table: MarketTableView = {
         id,
-        flea_market_id: payload.fleaMarketId,
+        fleaMarketId: payload.fleaMarketId,
         label: payload.label,
         description: payload.description ?? null,
-        price_sek: payload.priceSek,
-        size_description: payload.sizeDescription ?? null,
-        is_available: true,
-        max_per_day: 1,
-        sort_order: store.size,
-      } as MarketTable
+        priceSek: payload.priceSek,
+        sizeDescription: payload.sizeDescription ?? null,
+        isAvailable: true,
+        maxPerDay: 1,
+        sortOrder: store.size,
+      }
       store.set(id, table)
       return { id }
     },

--- a/packages/shared/src/adapters/supabase/flea-markets.ts
+++ b/packages/shared/src/adapters/supabase/flea-markets.ts
@@ -14,13 +14,13 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import type {
   FleaMarket,
   FleaMarketDetails,
-  MarketTable,
   CreateFleaMarketPayload,
   UpdateFleaMarketPayload,
   CreateMarketTablePayload,
   SearchResult,
+  MarketTableRow,
 } from '../../types'
-import type { FleaMarketNearByView } from '../../types/domain'
+import type { FleaMarketNearByView, MarketTableView } from '../../types/domain'
 import { FleaMarketQuery, type FleaMarketDetailsRow } from '../../query/flea-market'
 import type { FleaMarketRepository, SearchRepository, MarketTableRepository, WeekendOpenSlot } from '../../ports/flea-markets'
 
@@ -290,6 +290,33 @@ export function createSupabaseSearch(supabase: SupabaseClient): SearchRepository
   }
 }
 
+function mapMarketTableRow(row: MarketTableRow): MarketTableView {
+  return {
+    id: row.id,
+    fleaMarketId: row.flea_market_id,
+    label: row.label,
+    description: row.description,
+    priceSek: row.price_sek,
+    sizeDescription: row.size_description,
+    isAvailable: row.is_available,
+    maxPerDay: row.max_per_day,
+    sortOrder: row.sort_order,
+  }
+}
+
+function toMarketTableColumns(updates: Partial<MarketTableView>): Record<string, unknown> {
+  const cols: Record<string, unknown> = {}
+  if (updates.fleaMarketId !== undefined) cols['flea_market_id'] = updates.fleaMarketId
+  if (updates.label !== undefined) cols['label'] = updates.label
+  if (updates.description !== undefined) cols['description'] = updates.description
+  if (updates.priceSek !== undefined) cols['price_sek'] = updates.priceSek
+  if (updates.sizeDescription !== undefined) cols['size_description'] = updates.sizeDescription
+  if (updates.isAvailable !== undefined) cols['is_available'] = updates.isAvailable
+  if (updates.maxPerDay !== undefined) cols['max_per_day'] = updates.maxPerDay
+  if (updates.sortOrder !== undefined) cols['sort_order'] = updates.sortOrder
+  return cols
+}
+
 export function createSupabaseMarketTables(supabase: SupabaseClient): MarketTableRepository {
   return {
     async list(fleaMarketId) {
@@ -300,7 +327,7 @@ export function createSupabaseMarketTables(supabase: SupabaseClient): MarketTabl
         .eq('is_available', true)
         .order('sort_order')
       if (error) throw error
-      return (data ?? []) as MarketTable[]
+      return (data ?? [] as MarketTableRow[]).map(mapMarketTableRow)
     },
 
     async create(payload) {
@@ -320,9 +347,10 @@ export function createSupabaseMarketTables(supabase: SupabaseClient): MarketTabl
     },
 
     async update(id, updates) {
+      const cols = toMarketTableColumns(updates)
       const { error } = await supabase
         .from('market_tables')
-        .update(updates)
+        .update(cols)
         .eq('id', id)
       if (error) throw error
     },

--- a/packages/shared/src/ports/flea-markets.ts
+++ b/packages/shared/src/ports/flea-markets.ts
@@ -17,13 +17,12 @@
 import type {
   FleaMarket,
   FleaMarketDetails,
-  MarketTable,
   CreateFleaMarketPayload,
   UpdateFleaMarketPayload,
   CreateMarketTablePayload,
   SearchResult,
 } from '../types'
-import type { FleaMarketNearByView } from '../types/domain'
+import type { FleaMarketNearByView, MarketTableView } from '../types/domain'
 import type { Publishable } from './publishable'
 
 export type WeekendOpenSlot = {
@@ -64,8 +63,8 @@ export interface SearchRepository {
 }
 
 export interface MarketTableRepository {
-  list(fleaMarketId: string): Promise<MarketTable[]>
+  list(fleaMarketId: string): Promise<MarketTableView[]>
   create(payload: CreateMarketTablePayload): Promise<{ id: string }>
-  update(id: string, updates: Partial<MarketTable>): Promise<void>
+  update(id: string, updates: Partial<MarketTableView>): Promise<void>
   delete(id: string): Promise<void>
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -63,7 +63,6 @@ import type {
   OpeningHourRuleRow,
   OpeningHourExceptionRow,
   FleaMarketImageRow,
-  MarketTableRow,
   BookingRow as BookingDbRow,
   RouteRow,
 } from './db'
@@ -90,9 +89,6 @@ export type OrganizerStats = {
   total_revenue_sek: number
   total_commission_sek: number
 }
-
-// Market tables
-export type MarketTable = MarketTableRow
 
 // Bookings
 export type Booking = BookingDbRow

--- a/web/src/app/fleamarkets/[id]/edit/page.tsx
+++ b/web/src/app/fleamarkets/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from 'next/navigation'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import type { FleaMarketDetails, MarketTable } from '@fyndstigen/shared'
+import type { FleaMarketDetails, MarketTableView } from '@fyndstigen/shared'
 import { useAuth } from '@/lib/auth/auth-context'
 import { useDeps } from '@/providers/deps-provider'
 import { useMarketDetails } from '@/hooks/use-market-details'
@@ -27,7 +27,7 @@ export default function EditMarketPage() {
 
   const { market, tables: fetchedTables, loading: marketLoading } = useMarketDetails(id)
 
-  const [initial, setInitial] = useState<(FleaMarketDetails & { market_tables?: MarketTable[] }) | undefined>()
+  const [initial, setInitial] = useState<(FleaMarketDetails & { market_tables?: MarketTableView[] }) | undefined>()
   const [publishedAt, setPublishedAt] = useState<string | null>(null)
   const [initialised, setInitialised] = useState(false)
 

--- a/web/src/components/booking/tables-card.test.tsx
+++ b/web/src/components/booking/tables-card.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { BookableTablesCard } from './tables-card'
-import type { MarketTable } from '@fyndstigen/shared'
+import type { MarketTableView } from '@fyndstigen/shared'
 
 vi.mock('@/lib/flags', () => ({ useFlag: () => true, getFlagEnv: () => true }))
 vi.mock('@/lib/auth/auth-context', () => ({ useAuth: vi.fn() }))
@@ -21,25 +21,23 @@ import { useBooking } from '@/hooks/use-booking'
 const mockUseAuth = useAuth as ReturnType<typeof vi.fn>
 const mockUseBooking = useBooking as ReturnType<typeof vi.fn>
 
-const paidTable: MarketTable = {
+const paidTable: MarketTableView = {
   id: 't1',
-  flea_market_id: 'fm1',
+  fleaMarketId: 'fm1',
   label: 'Bord A',
   description: 'Inne',
-  price_sek: 200,
-  size_description: '2x1m',
-  is_available: true,
-  max_per_day: 1,
-  sort_order: 0,
-  created_at: '',
-  updated_at: '',
+  priceSek: 200,
+  sizeDescription: '2x1m',
+  isAvailable: true,
+  maxPerDay: 1,
+  sortOrder: 0,
 }
 
-const freeTable: MarketTable = {
+const freeTable: MarketTableView = {
   ...paidTable,
   id: 't2',
   label: 'Bord B',
-  price_sek: 0,
+  priceSek: 0,
 }
 
 const defaultBooking = {

--- a/web/src/components/booking/tables-card.tsx
+++ b/web/src/components/booking/tables-card.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { Elements, CardElement } from '@stripe/react-stripe-js'
-import type { MarketTable } from '@fyndstigen/shared'
+import type { MarketTableView } from '@fyndstigen/shared'
 import { useAuth } from '@/lib/auth/auth-context'
 import { useBooking } from '@/hooks/use-booking'
 import type { OpeningHoursContext } from '@fyndstigen/shared'
@@ -19,7 +19,7 @@ function BookableTablesInner({
 }: {
   fleaMarketId: string
   fleaMarketName: string
-  tables: MarketTable[]
+  tables: MarketTableView[]
   openingHours?: OpeningHoursContext
 }) {
   const { user } = useAuth()
@@ -63,7 +63,7 @@ function BookableTablesInner({
                         posthog?.capture('booking_started', {
                           market_id: fleaMarketId,
                           table_count: tables.length,
-                          is_free: isFreePriced(next.price_sek),
+                          is_free: isFreePriced(next.priceSek),
                         })
                       }
                     }}
@@ -76,12 +76,12 @@ function BookableTablesInner({
                     <div>
                       <p className="font-medium text-sm">{table.label}</p>
                       <div className="flex items-center gap-2 mt-0.5 text-xs text-espresso/60">
-                        {table.size_description && <span>{table.size_description}</span>}
+                        {table.sizeDescription && <span>{table.sizeDescription}</span>}
                         {table.description && <span>&middot; {table.description}</span>}
                       </div>
                     </div>
                     <span className="font-display font-bold text-rust">
-                      {table.price_sek === 0 ? 'Gratis' : `${table.price_sek} kr`}
+                      {table.priceSek === 0 ? 'Gratis' : `${table.priceSek} kr`}
                     </span>
                   </button>
 
@@ -179,14 +179,14 @@ export function BookableTablesCard({
 }: {
   fleaMarketId: string
   fleaMarketName: string
-  tables: MarketTable[]
+  tables: MarketTableView[]
   openingHours?: OpeningHoursContext
 }) {
   const paymentsEnabled = useFlag('payments')
   // When payments are off, only show free tables
   const visibleTables = paymentsEnabled
     ? tables
-    : tables.filter((t) => t.price_sek === 0)
+    : tables.filter((t) => t.priceSek === 0)
 
   if (visibleTables.length === 0) return null
 

--- a/web/src/hooks/market-form/use-market-form.ts
+++ b/web/src/hooks/market-form/use-market-form.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import type { FleaMarketDetails, MarketTable } from '@fyndstigen/shared'
+import type { FleaMarketDetails, MarketTableView } from '@fyndstigen/shared'
 import { useMarketFields } from './use-market-fields'
 import { useOpeningHoursDraft } from './use-opening-hours-draft'
 import { useImageDraft } from './use-image-draft'
@@ -17,7 +17,7 @@ export type { ImageDraftExisting } from './use-image-draft'
 export type UseMarketFormOptions = {
   mode: 'create' | 'edit'
   /** For edit mode: the full market details to initialize from. */
-  initial?: FleaMarketDetails & { market_tables?: MarketTable[] }
+  initial?: FleaMarketDetails & { market_tables?: MarketTableView[] }
   /** For create mode: the organizer's user id. */
   organizerId?: string
 }

--- a/web/src/hooks/market-form/use-table-draft.test.ts
+++ b/web/src/hooks/market-form/use-table-draft.test.ts
@@ -1,14 +1,17 @@
 import { renderHook, act } from '@testing-library/react'
 import { useTableDraft } from './use-table-draft'
-import type { MarketTable } from '@fyndstigen/shared'
+import type { MarketTableView } from '@fyndstigen/shared'
 
-const dbTable: MarketTable = {
+const dbTable: MarketTableView = {
   id: 't-1',
-  flea_market_id: 'mkt-1',
+  fleaMarketId: 'mkt-1',
   label: 'Bord 1',
   description: 'Stort bord',
-  price_sek: 200,
-  size_description: '2x1m',
+  priceSek: 200,
+  sizeDescription: '2x1m',
+  isAvailable: true,
+  maxPerDay: 1,
+  sortOrder: 0,
 }
 
 describe('useTableDraft', () => {

--- a/web/src/hooks/market-form/use-table-draft.ts
+++ b/web/src/hooks/market-form/use-table-draft.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useMemo, useState } from 'react'
-import type { MarketTable } from '@fyndstigen/shared'
+import type { MarketTableView } from '@fyndstigen/shared'
 
 export type TableDraftRow = {
   id?: string // present for existing DB rows
@@ -19,7 +19,7 @@ export type TableDraftResult = {
   removeNew: (index: number) => void
   markDeleted: (id: string) => void
   undoDelete: (id: string) => void
-  reset: (tables: MarketTable[]) => void
+  reset: (tables: MarketTableView[]) => void
   resetNew: () => void
   serialize: () => {
     add: { label: string; description: string; priceSek: number; sizeDescription: string }[]
@@ -27,19 +27,19 @@ export type TableDraftResult = {
   }
 }
 
-function fromMarketTable(t: MarketTable): TableDraftRow {
+function fromMarketTableView(t: MarketTableView): TableDraftRow {
   return {
     id: t.id,
     label: t.label,
     description: t.description ?? '',
-    priceSek: t.price_sek,
-    sizeDescription: t.size_description ?? '',
+    priceSek: t.priceSek,
+    sizeDescription: t.sizeDescription ?? '',
   }
 }
 
-export function useTableDraft(initialTables: MarketTable[] = []): TableDraftResult {
+export function useTableDraft(initialTables: MarketTableView[] = []): TableDraftResult {
   const [existingTables, setExistingTables] = useState<TableDraftRow[]>(
-    () => initialTables.map(fromMarketTable),
+    () => initialTables.map(fromMarketTableView),
   )
   const [newTables, setNewTables] = useState<TableDraftRow[]>([])
 
@@ -63,8 +63,8 @@ export function useTableDraft(initialTables: MarketTable[] = []): TableDraftResu
     )
   }, [])
 
-  const reset = useCallback((tables: MarketTable[]) => {
-    setExistingTables(tables.map(fromMarketTable))
+  const reset = useCallback((tables: MarketTableView[]) => {
+    setExistingTables(tables.map(fromMarketTableView))
     setNewTables([])
   }, [])
 

--- a/web/src/hooks/use-booking-payment.test.ts
+++ b/web/src/hooks/use-booking-payment.test.ts
@@ -61,16 +61,14 @@ async function* makeStream(events: BookingProgress[]): AsyncIterable<BookingProg
 
 const mockTable = {
   id: 'table-1',
-  flea_market_id: 'market-1',
+  fleaMarketId: 'market-1',
   label: 'Bord A1',
   description: null,
-  price_sek: 200,
-  size_description: '2x1m',
-  is_available: true,
-  max_per_day: 1,
-  sort_order: 0,
-  created_at: '',
-  updated_at: '',
+  priceSek: 200,
+  sizeDescription: '2x1m',
+  isAvailable: true,
+  maxPerDay: 1,
+  sortOrder: 0,
 }
 
 describe('useBooking — payment edge cases', () => {
@@ -351,8 +349,8 @@ describe('useBooking — payment edge cases', () => {
     const { result: r1 } = renderHook(() => useBooking('m-1', 'u-1'), { wrapper })
     const { result: r2 } = renderHook(() => useBooking('m-1', 'u-1'), { wrapper })
 
-    act(() => { r1.current.selectTable({ ...mockTable, price_sek: 100 }) })
-    act(() => { r2.current.selectTable({ ...mockTable, price_sek: 500 }) })
+    act(() => { r1.current.selectTable({ ...mockTable, priceSek: 100 }) })
+    act(() => { r2.current.selectTable({ ...mockTable, priceSek: 500 }) })
 
     expect(r1.current.commission).toBe(12)
     expect(r1.current.totalPrice).toBe(112)
@@ -363,10 +361,10 @@ describe('useBooking — payment edge cases', () => {
   it('changing table recalculates prices', () => {
     const { result } = renderHook(() => useBooking('m-1', 'u-1'), { wrapper })
 
-    act(() => { result.current.selectTable({ ...mockTable, price_sek: 100 }) })
+    act(() => { result.current.selectTable({ ...mockTable, priceSek: 100 }) })
     expect(result.current.totalPrice).toBe(112)
 
-    act(() => { result.current.selectTable({ ...mockTable, price_sek: 300 }) })
+    act(() => { result.current.selectTable({ ...mockTable, priceSek: 300 }) })
     expect(result.current.totalPrice).toBe(336)
   })
 

--- a/web/src/hooks/use-booking.test.ts
+++ b/web/src/hooks/use-booking.test.ts
@@ -91,23 +91,21 @@ const saturdayOnlyHours: OpeningHoursContext = {
 
 const mockTable = {
   id: 'table-1',
-  flea_market_id: 'market-1',
+  fleaMarketId: 'market-1',
   label: 'Bord A1',
   description: null,
-  price_sek: 200,
-  size_description: '2x1m',
-  is_available: true,
-  max_per_day: 1,
-  sort_order: 0,
-  created_at: '',
-  updated_at: '',
+  priceSek: 200,
+  sizeDescription: '2x1m',
+  isAvailable: true,
+  maxPerDay: 1,
+  sortOrder: 0,
 }
 
 const mockFreeTable = {
   ...mockTable,
   id: 'table-free',
   label: 'Gratisbord B1',
-  price_sek: 0,
+  priceSek: 0,
 }
 
 /** Default happy-path stream for a paid booking. */
@@ -483,7 +481,7 @@ describe('useBooking', () => {
   })
 
   it('commission and totalPrice update when table changes', () => {
-    const expensiveTable = { ...mockTable, id: 'table-2', price_sek: 500 }
+    const expensiveTable = { ...mockTable, id: 'table-2', priceSek: 500 }
     const { result } = renderHook(() => useBooking('market-1', 'Loppis A', 'user-1'), { wrapper })
 
     act(() => { result.current.selectTable(mockTable) })
@@ -793,8 +791,8 @@ describe('useBooking', () => {
     const { result: r1 } = renderHook(() => useBooking('m-1', 'u-1'), { wrapper })
     const { result: r2 } = renderHook(() => useBooking('m-1', 'u-1'), { wrapper })
 
-    act(() => { r1.current.selectTable({ ...mockTable, price_sek: 100 }) })
-    act(() => { r2.current.selectTable({ ...mockTable, price_sek: 500 }) })
+    act(() => { r1.current.selectTable({ ...mockTable, priceSek: 100 }) })
+    act(() => { r2.current.selectTable({ ...mockTable, priceSek: 500 }) })
 
     expect(r1.current.commission).toBe(12)
     expect(r1.current.totalPrice).toBe(112)
@@ -805,10 +803,10 @@ describe('useBooking', () => {
   it('changing table recalculates prices', () => {
     const { result } = renderHook(() => useBooking('m-1', 'u-1'), { wrapper })
 
-    act(() => { result.current.selectTable({ ...mockTable, price_sek: 100 }) })
+    act(() => { result.current.selectTable({ ...mockTable, priceSek: 100 }) })
     expect(result.current.totalPrice).toBe(112)
 
-    act(() => { result.current.selectTable({ ...mockTable, price_sek: 300 }) })
+    act(() => { result.current.selectTable({ ...mockTable, priceSek: 300 }) })
     expect(result.current.totalPrice).toBe(336)
   })
 

--- a/web/src/hooks/use-booking.ts
+++ b/web/src/hooks/use-booking.ts
@@ -23,7 +23,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useStripe, useElements } from '@stripe/react-stripe-js'
 import { bookingService } from '@/lib/booking-service'
-import type { MarketTable } from '@fyndstigen/shared'
+import type { MarketTableView } from '@fyndstigen/shared'
 import { isFreePriced, messageFor } from '@fyndstigen/shared'
 import type { AppError, OpeningHoursContext } from '@fyndstigen/shared'
 import { usePostHog } from 'posthog-js/react'
@@ -31,11 +31,11 @@ import { useDeps } from '@/providers/deps-provider'
 import { resolvePaymentGateway } from '@/lib/stripe/gateway-factory'
 
 type BookingHook = {
-  selectedTable: MarketTable | null
+  selectedTable: MarketTableView | null
   date: string
   message: string
   bookedDates: string[]
-  selectTable: (table: MarketTable | null) => void
+  selectTable: (table: MarketTableView | null) => void
   setDate: (date: string) => void
   setMessage: (msg: string) => void
   /** Swedish user-facing validation message, or null when date is valid/empty */
@@ -62,7 +62,7 @@ export function useBooking(
   const stripe = useStripe()
   const elements = useElements()
   const { bookings } = useDeps()
-  const [selectedTable, setSelectedTable] = useState<MarketTable | null>(null)
+  const [selectedTable, setSelectedTable] = useState<MarketTableView | null>(null)
   const [date, setDate] = useState('')
   const [message, setMessage] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -94,7 +94,7 @@ export function useBooking(
       ? messageFor(dateValidation.code, dateValidation.params)
       : null
 
-  const price = selectedTable?.price_sek ?? 0
+  const price = selectedTable?.priceSek ?? 0
   const isFree = isFreePriced(price)
   const { commission, total: totalPrice } = bookingService.calculateTotal(price)
 
@@ -105,7 +105,7 @@ export function useBooking(
     if (!canSubmit || !selectedTable) return
     setSubmitError(null)
 
-    const priceSek = selectedTable.price_sek
+    const priceSek = selectedTable.priceSek
     const payment = resolvePaymentGateway({ stripe, elements })
 
     const stream = bookingService.book(

--- a/web/src/hooks/use-market-detail-view-model.ts
+++ b/web/src/hooks/use-market-detail-view-model.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import type {
   FleaMarketDetails,
   FleaMarketImageView,
-  MarketTable,
+  MarketTableView,
   OpeningHourRuleView,
   OpeningHourExceptionView,
 } from '@fyndstigen/shared'
@@ -14,7 +14,7 @@ import { useMarketDetails } from './use-market-details'
 
 export type MarketDetailViewModel = {
   market: FleaMarketDetails | null
-  tables: MarketTable[]
+  tables: MarketTableView[]
   /** Sorted by sortOrder ascending. Empty array if the market has no images. */
   images: FleaMarketImageView[]
   /** Undefined when the market has neither rules nor exceptions. */

--- a/web/src/hooks/use-market-details.ts
+++ b/web/src/hooks/use-market-details.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import type { FleaMarketDetails, MarketTable } from '@fyndstigen/shared'
+import type { FleaMarketDetails, MarketTableView } from '@fyndstigen/shared'
 import { queryKeys } from '@/lib/query-keys'
 import { useDeps } from '@/providers/deps-provider'
 
@@ -17,7 +17,7 @@ export function useMarketDetails(id: string | undefined) {
   })
   return {
     market: data?.market ?? (null as FleaMarketDetails | null),
-    tables: data?.tables ?? ([] as MarketTable[]),
+    tables: data?.tables ?? ([] as MarketTableView[]),
     loading: isLoading,
     error: error?.message ?? null,
   }


### PR DESCRIPTION
Partial #110.

12 callers + port-contract change for `MarketTableRepository.update()`. Supabase adapter introduces `toMarketTableColumns()` to map the `Partial<MarketTableView>` payload to snake_case DB columns; in-memory adapter stores View shapes natively.

16 files. No edge functions touched (no edge fn imports MarketTable).

## Test plan
- [x] packages/shared 735, web tsc clean
- [ ] CI