### PR TITLE
refactor(types): migrate Booking alias → BookingDbRow (batch 10 — closes #110)

### DIFF
--- a/packages/shared/src/adapters/in-memory/booking-repo.test.ts
+++ b/packages/shared/src/adapters/in-memory/booking-repo.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { createInMemoryBookingRepo, type InMemoryBookingRepo } from './booking-repo'
-import type { Booking } from '../../types'
+import type { BookingDbRow } from '../../types'
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
-function makeBooking(overrides: Partial<Booking> = {}): Booking {
+function makeBooking(overrides: Partial<BookingDbRow> = {}): BookingDbRow {
   return {
     id: 'bk-1',
     market_table_id: 'mt-1',

--- a/packages/shared/src/adapters/in-memory/booking-repo.ts
+++ b/packages/shared/src/adapters/in-memory/booking-repo.ts
@@ -8,13 +8,13 @@
 
 import { applyBookingEvent } from '../../domain/booking-lifecycle'
 import type { BookingEvent } from '../../domain/booking-lifecycle'
-import type { Booking } from '../../types'
+import type { BookingDbRow } from '../../types'
 import type { BookingRepo } from '../../ports/booking-repo'
 
 let _id = 1
 
-export function createInMemoryBookingRepo(seed: Booking[] = []): BookingRepo {
-  const store = new Map<string, Booking>(seed.map((b) => [b.id, { ...b }]))
+export function createInMemoryBookingRepo(seed: BookingDbRow[] = []): BookingRepo {
+  const store = new Map<string, BookingDbRow>(seed.map((b) => [b.id, { ...b }]))
   // market-level auto_accept flag, keyed by flea_market_id
   const autoAcceptByMarket = new Map<string, boolean>()
 
@@ -26,9 +26,9 @@ export function createInMemoryBookingRepo(seed: Booking[] = []): BookingRepo {
    * Convenience: insert a booking directly into the store (not part of the
    * BookingRepo interface — test setup only).
    */
-  function insert(booking: Omit<Booking, 'id'> & { id?: string }): Booking {
+  function insert(booking: Omit<BookingDbRow, 'id'> & { id?: string }): BookingDbRow {
     const id = booking.id ?? nextId()
-    const full: Booking = { ...booking, id } as Booking
+    const full: BookingDbRow = { ...booking, id } as BookingDbRow
     store.set(id, full)
     return full
   }
@@ -66,7 +66,7 @@ export function createInMemoryBookingRepo(seed: Booking[] = []): BookingRepo {
       const patch = applyBookingEvent(current, event)
       if (Object.keys(patch).length === 0) return { ...current }
 
-      const updated: Booking = { ...current, ...patch } as Booking
+      const updated: BookingDbRow = { ...current, ...patch } as BookingDbRow
       store.set(id, updated)
       return { ...updated }
     },
@@ -80,6 +80,6 @@ export function createInMemoryBookingRepo(seed: Booking[] = []): BookingRepo {
  * created by `createInMemoryBookingRepo`.
  */
 export type InMemoryBookingRepo = BookingRepo & {
-  _insert(booking: Omit<Booking, 'id'> & { id?: string }): Booking
+  _insert(booking: Omit<BookingDbRow, 'id'> & { id?: string }): BookingDbRow
   _setAutoAccept(marketId: string, autoAccept: boolean): void
 }

--- a/packages/shared/src/adapters/supabase/booking-repo.test.ts
+++ b/packages/shared/src/adapters/supabase/booking-repo.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { createSupabaseBookingRepo } from './booking-repo'
-import type { Booking } from '../../types'
+import type { BookingDbRow } from '../../types'
 
 // Minimal fake of the chainable Supabase query builder.
 function makeFakeClient(opts: {
@@ -76,7 +76,7 @@ function makeFindByPIClient(opts: {
   return client
 }
 
-function seedRow(): Booking & { created_at: string } {
+function seedRow(): BookingDbRow & { created_at: string } {
   return {
     id: 'b1',
     status: 'pending',

--- a/packages/shared/src/adapters/supabase/booking-repo.ts
+++ b/packages/shared/src/adapters/supabase/booking-repo.ts
@@ -12,7 +12,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { applyBookingEvent } from '../../domain/booking-lifecycle'
 import type { BookingEvent } from '../../domain/booking-lifecycle'
-import type { Booking } from '../../types'
+import type { BookingDbRow } from '../../types'
 import type { BookingRepo } from '../../ports/booking-repo'
 import { BookingQuery } from '../../query/booking'
 
@@ -25,7 +25,7 @@ export function createSupabaseBookingRepo(admin: SupabaseClient): BookingRepo {
         .eq('id', id)
         .single()
       if (error || !data) return null
-      return data as unknown as Booking
+      return data as unknown as BookingDbRow
     },
 
     async findByPaymentIntent(paymentIntentId) {
@@ -37,7 +37,7 @@ export function createSupabaseBookingRepo(admin: SupabaseClient): BookingRepo {
       if (error || !data) return null
       const { flea_markets, ...bookingData } = data as unknown as Record<string, unknown> & { flea_markets: { auto_accept_bookings: boolean } }
       return {
-        booking: bookingData as unknown as Booking,
+        booking: bookingData as unknown as BookingDbRow,
         autoAccept: !!flea_markets?.auto_accept_bookings,
       }
     },
@@ -52,7 +52,7 @@ export function createSupabaseBookingRepo(admin: SupabaseClient): BookingRepo {
       // eslint-disable-next-line no-restricted-syntax -- adapter-level invariant: missing booking after explicit lookup is a data integrity failure, not a user-facing error
       if (fetchErr || !booking) throw new Error(`Booking ${id} not found`)
 
-      const current = booking as unknown as Booking
+      const current = booking as unknown as BookingDbRow
       const patch = applyBookingEvent(current, event)
 
       // Empty patch → illegal / already-terminal transition; return current unchanged.
@@ -80,10 +80,10 @@ export function createSupabaseBookingRepo(admin: SupabaseClient): BookingRepo {
           .single()
         // eslint-disable-next-line no-restricted-syntax -- adapter-level invariant: booking disappeared between concurrent operations; indicates a data integrity issue
         if (!refetched) throw new Error(`Booking ${id} disappeared after lost update`)
-        return refetched as unknown as Booking
+        return refetched as unknown as BookingDbRow
       }
 
-      return updated as unknown as Booking
+      return updated as unknown as BookingDbRow
     },
   }
 }

--- a/packages/shared/src/domain/booking-lifecycle.test.ts
+++ b/packages/shared/src/domain/booking-lifecycle.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { applyBookingEvent, type BookingEvent, type BookingPatch } from './booking-lifecycle'
-import type { Booking, BookingStatus } from '../types'
+import type { BookingDbRow, BookingStatus } from '../types'
 
 const FIXED_NOW = new Date('2026-04-21T12:00:00.000Z')
 
-function makeBooking(overrides: Partial<Booking> = {}): Booking {
+function makeBooking(overrides: Partial<BookingDbRow> = {}): BookingDbRow {
   return {
     id: 'booking-1',
     market_table_id: 'table-1',

--- a/packages/shared/src/domain/booking-lifecycle.ts
+++ b/packages/shared/src/domain/booking-lifecycle.ts
@@ -10,7 +10,7 @@
  * supabase/functions/deno.json — no mirror needed.
  */
 
-import type { Booking, BookingStatus, PaymentStatus } from '../types'
+import type { BookingDbRow, BookingStatus, PaymentStatus } from '../types'
 import { decidePaidBooking } from './booking'
 
 // Events that drive the lifecycle.
@@ -28,9 +28,9 @@ export type BookingEvent =
   | { type: 'organizer.deny' }
   | { type: 'user.cancel' }
 
-// Subset of `Booking` columns the reducer may patch. Timestamp columns
+// Subset of `BookingDbRow` columns the reducer may patch. Timestamp columns
 // (captured_at, cancelled_at, denied_at) are stamped as ISO strings but are
-// not present on the `Booking` row type — they exist only in the DB schema
+// not present on the `BookingDbRow` row type — they exist only in the DB schema
 // and are surfaced here so the patch carries them through to the UPDATE.
 export type BookingPatch = Partial<{
   status: BookingStatus
@@ -50,7 +50,7 @@ export type BookingPatch = Partial<{
  * @param now injectable clock for deterministic testing.
  */
 export function applyBookingEvent(
-  current: Booking,
+  current: BookingDbRow,
   event: BookingEvent,
   now: Date = new Date(),
 ): BookingPatch {

--- a/packages/shared/src/domain/booking-service.test.ts
+++ b/packages/shared/src/domain/booking-service.test.ts
@@ -3,7 +3,7 @@ import { createBookingService } from './booking-service'
 import type { BookingProgress, OpeningHoursContext } from './booking-service'
 import { isAppError } from '../errors'
 import type { Api } from '../api'
-import type { Booking } from '../types'
+import type { BookingDbRow } from '../types'
 import type { PaymentGateway } from '../ports/payment'
 
 // ---------------------------------------------------------------------------
@@ -253,7 +253,7 @@ describe('BookingService.cancel', () => {
 describe('BookingService.applyEvent', () => {
   it('is a pass-through to applyBookingEvent', () => {
     const svc = createBookingService({ api: makeApi() })
-    const booking: Booking = {
+    const booking: BookingDbRow = {
       id: 'b-1',
       market_table_id: 'tbl-1',
       flea_market_id: 'mkt-1',

--- a/packages/shared/src/domain/booking-service.ts
+++ b/packages/shared/src/domain/booking-service.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Api } from '../api'
-import type { Booking } from '../types'
+import type { BookingDbRow } from '../types'
 
 /**
  * Narrow API surface required by createBookingService.
@@ -115,7 +115,7 @@ export type BookingService = {
   cancel(bookingId: string, reason: 'denied' | 'cancelled'): Promise<void>
 
   /** Pure lifecycle reducer — re-export of booking-lifecycle.applyBookingEvent. */
-  applyEvent(current: Booking, event: BookingEvent): BookingPatch
+  applyEvent(current: BookingDbRow, event: BookingEvent): BookingPatch
 }
 
 /**

--- a/packages/shared/src/ports/booking-repo.ts
+++ b/packages/shared/src/ports/booking-repo.ts
@@ -13,14 +13,14 @@
  * concurrency), exactly as the original edges do.
  */
 
-import type { Booking } from '../types'
+import type { BookingDbRow } from '../types'
 import type { BookingEvent } from '../domain/booking-lifecycle'
 
 export interface BookingRepo {
   /**
    * Find a booking by its primary key. Returns null if not found.
    */
-  findById(id: string): Promise<Booking | null>
+  findById(id: string): Promise<BookingDbRow | null>
 
   /**
    * Find a booking by its Stripe PaymentIntent ID. Returns null if not found
@@ -29,7 +29,7 @@ export interface BookingRepo {
    * Also returns the market's auto_accept_bookings flag in a single round-trip
    * join so callers don't need a separate market lookup.
    */
-  findByPaymentIntent(paymentIntentId: string): Promise<{ booking: Booking; autoAccept: boolean } | null>
+  findByPaymentIntent(paymentIntentId: string): Promise<{ booking: BookingDbRow; autoAccept: boolean } | null>
 
   /**
    * Apply a lifecycle event to the booking identified by `id`.
@@ -41,5 +41,5 @@ export interface BookingRepo {
    *
    * Throws if the booking does not exist or if the DB UPDATE fails.
    */
-  applyEvent(id: string, event: BookingEvent): Promise<Booking>
+  applyEvent(id: string, event: BookingEvent): Promise<BookingDbRow>
 }

--- a/packages/shared/src/query/booking.ts
+++ b/packages/shared/src/query/booking.ts
@@ -3,7 +3,7 @@
  * booking query shape. Mirrors the FleaMarketQuery pattern (RFC #34).
  *
  * Three variants today:
- *   - core: scalar columns only, returns Booking (used by booking-repo for
+ *   - core: scalar columns only, returns BookingDbRow (used by booking-repo for
  *           lifecycle reads/writes — no joins, deterministic shape)
  *   - withMarketAndTable: bookings joined with flea_markets + market_tables
  *           (the user's "my bookings" view)
@@ -16,7 +16,7 @@
  */
 
 import type { Database } from '../types/supabase.generated'
-import type { Booking } from '../types'
+import type { BookingDbRow } from '../types'
 import type { BookingView } from '../types/domain'
 import { mapBookingView, type BookingRow } from '../api/mappers'
 
@@ -32,8 +32,8 @@ const CORE_COLUMNS = [
 export const BookingQuery = {
   core: {
     select: CORE_COLUMNS.join(', ') as string,
-    mapRow(row: Pick<BookingTableRow, typeof CORE_COLUMNS[number]>): Booking {
-      return row as Booking
+    mapRow(row: Pick<BookingTableRow, typeof CORE_COLUMNS[number]>): BookingDbRow {
+      return row as BookingDbRow
     },
   },
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -59,9 +59,6 @@ export type {
 // ============================================================
 
 import type {
-  BookingRow as BookingDbRow,
-} from './db'
-import type {
   BookingStatus,
   PaymentStatus,
   RuleType,
@@ -76,9 +73,6 @@ export type OrganizerStats = {
   total_revenue_sek: number
   total_commission_sek: number
 }
-
-// Bookings
-export type Booking = BookingDbRow
 
 // Payloads (these were already camelCase — no aliases needed)
 export type AddressPayload = {

--- a/supabase/functions/stripe-webhooks/execute.test.ts
+++ b/supabase/functions/stripe-webhooks/execute.test.ts
@@ -13,7 +13,7 @@ import { assertEquals, assertRejects } from 'https://deno.land/std@0.177.0/testi
 import { executeCommand, type WebhookRepos } from './execute.ts'
 import type { WebhookCommand } from '@fyndstigen/shared/stripe-webhook.ts'
 import type { Logger } from '@fyndstigen/shared/ports/logger.ts'
-import type { Booking } from '@fyndstigen/shared/types/index.ts'
+import type { BookingDbRow } from '@fyndstigen/shared/types/index.ts'
 
 // ---------------------------------------------------------------------------
 // In-memory repo stubs
@@ -27,7 +27,7 @@ function makeBookingRepo(opts: { throwOnApply?: boolean } = {}) {
     async applyEvent(id: string, event: unknown) {
       if (opts.throwOnApply) throw new Error('DB error')
       calls.push({ id, event })
-      return {} as Booking
+      return {} as BookingDbRow
     },
     _calls: calls,
   }


### PR DESCRIPTION
Closes #110.

Final batch of the snake_case alias migration. The audit warned the Booking cluster would need port-contract restructuring, but on inspection every consumer of the `Booking` alias was on the domain/lifecycle path — they correctly want the raw DB row shape since the lifecycle reducer reads snake_case fields directly.

UI consumers had already migrated to the BookingView event stream via the BookingProgress refactor (#84). They use the typed event shape and never import the Booking type.

This batch is therefore a pure rename: `Booking` → `BookingDbRow`. 12 files. Alias deleted.

`OrganizerStats` (the only remaining snake_case alias) has no `*View` counterpart and was explicitly out of scope per the audit.

## Test plan
- [x] packages/shared 735, web tsc clean, edge-imports clean
- [ ] CI