### PR TITLE
feat(edge): AlertSink port for contract violations + exceptions

### DIFF
--- a/supabase/functions/_shared/alerting.ts
+++ b/supabase/functions/_shared/alerting.ts
@@ -1,0 +1,79 @@
+/**
+ * AlertSink — port for surfacing operational problems beyond Supabase logs.
+ *
+ * Today: contract violations and uncaught exceptions go to `console.error`
+ * and live only in Supabase Edge logs (where nobody is paged). This port
+ * lets a real alerting backend (Sentry, Slack webhook, log-drain) be wired
+ * in by swapping the singleton in `getAlertSink()` — no per-endpoint change.
+ *
+ * Two event types:
+ *   - `captureViolation`: zod output-contract failure. Non-fatal in 'warn'
+ *     mode; the response still goes out to the client. We want eyes on
+ *     these because they indicate schema drift between the edge function
+ *     and its callers.
+ *   - `captureException`: an unhandled throw inside an endpoint handler.
+ *     The user already got a 4xx/5xx; this is the operator-side signal.
+ *
+ * Adapters: today only the console sink exists. Add Sentry / Slack
+ * adapters next to this file and switch `getAlertSink()` to use them.
+ *
+ * Tracked: #113.
+ */
+
+export type AlertContext = {
+  /** Endpoint name (e.g. 'booking-create') */
+  endpoint?: string
+  /** Authenticated user id, if available */
+  userId?: string
+  /** Anything else the caller wants to attach for debugging */
+  extra?: Record<string, unknown>
+}
+
+export interface AlertSink {
+  captureViolation(name: string, issues: unknown, context?: AlertContext): void
+  captureException(err: unknown, context?: AlertContext): void
+}
+
+/**
+ * Default sink — emits structured JSON to stderr so Supabase Edge logs
+ * keep their existing shape. Same behavior as before this port existed.
+ */
+export function createConsoleSink(): AlertSink {
+  return {
+    captureViolation(name, issues, context) {
+      const payload = {
+        kind: 'output_contract_violation',
+        endpoint: name,
+        issues,
+        ...context,
+      }
+      console.error(JSON.stringify(payload))
+    },
+    captureException(err, context) {
+      const payload = {
+        kind: 'edge_exception',
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+        ...context,
+      }
+      console.error(JSON.stringify(payload))
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton — resolved lazily so adapter selection can read env vars at
+// first-use time. Tests can inject a sink via `setAlertSink(fakeSink)`.
+// ---------------------------------------------------------------------------
+
+let _sink: AlertSink | null = null
+
+export function getAlertSink(): AlertSink {
+  if (!_sink) _sink = createConsoleSink()
+  return _sink
+}
+
+/** Test seam. Reset between tests. */
+export function setAlertSink(sink: AlertSink | null): void {
+  _sink = sink
+}

--- a/supabase/functions/_shared/endpoint.ts
+++ b/supabase/functions/_shared/endpoint.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { createHandler, HttpError, type RequestContext } from './handler.ts'
+import { getAlertSink } from './alerting.ts'
 
 /**
  * Typed edge-function endpoint backed by Zod contracts.
@@ -22,7 +23,10 @@ import { createHandler, HttpError, type RequestContext } from './handler.ts'
  * The legacy `SUPABASE_ENVIRONMENT=development` flag is still honoured for
  * back-compat — remove once all setups have migrated to the new name.
  *
- * Alerting on warnings is tracked separately in #113.
+ * Contract violations and unhandled exceptions are routed through the
+ * AlertSink port (`./alerting.ts`). The default sink emits structured
+ * JSON to stderr (visible in Supabase Edge logs). Swap to a Sentry /
+ * Slack adapter by calling `setAlertSink()` at app startup. #113.
  */
 export type EndpointConfig<I, O> = {
   name: string
@@ -48,9 +52,15 @@ export function defineEndpoint<I, O>(config: EndpointConfig<I, O>): void {
       const env = (globalThis as { Deno?: { env: { get(k: string): string | undefined } } }).Deno?.env
       const mode = env?.get('OUTPUT_CONTRACT_MODE')
         ?? (env?.get('SUPABASE_ENVIRONMENT') === 'development' ? 'strict' : 'warn')
-      const msg = `[endpoint:${config.name}] output contract violation: ${JSON.stringify(parsedOutput.error.issues)}`
-      if (mode === 'strict') throw new Error(msg)
-      console.error(msg)
+      getAlertSink().captureViolation(config.name, parsedOutput.error.issues, {
+        endpoint: config.name,
+        userId: ctx.user.id,
+      })
+      if (mode === 'strict') {
+        throw new Error(
+          `[endpoint:${config.name}] output contract violation: ${JSON.stringify(parsedOutput.error.issues)}`,
+        )
+      }
       return result
     }
 

--- a/supabase/functions/_shared/handler.ts
+++ b/supabase/functions/_shared/handler.ts
@@ -1,6 +1,7 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { getCorsHeaders, corsResponse, getSafeOrigin } from './cors.ts'
 import { getUser, getSupabaseAdmin } from './auth.ts'
+import { getAlertSink } from './alerting.ts'
 import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 // Known error types for proper HTTP status codes
@@ -73,6 +74,13 @@ export function createHandler(fn: HandlerFn) {
 
       return new Response(JSON.stringify(result), { headers })
     } catch (error) {
+      // Route non-HttpError throws through the alert sink. HttpError is the
+      // intentional way handlers return 4xx — those are expected (validation,
+      // not-found, forbidden) and would be alert noise. Anything else is an
+      // unhandled exception worth knowing about.
+      if (!(error instanceof HttpError)) {
+        getAlertSink().captureException(error, { extra: { url: req.url } })
+      }
       const statusCode = error instanceof HttpError ? error.statusCode : 400
       const body =
         error instanceof HttpError && error.body !== undefined


### PR DESCRIPTION
Partial #113 (level A).

Adds `supabase/functions/_shared/alerting.ts` — an `AlertSink` interface with `captureViolation` + `captureException`, a default console sink, and a swappable singleton. Wires it into `endpoint.ts` (output-contract violations) and `handler.ts` (non-HttpError throws).

Same observable behavior as before — the console sink emits the same payload, just structured JSON. A future PR can add `createSentrySink(dsn)` (the Sentry MCP is available) or a Slack adapter without touching the call sites.

`HttpError` is intentionally NOT routed through `captureException` — those are 4xx by design (validation, forbidden, not-found) and would be alert noise.

## Test plan
- [x] packages/shared 735, web tsc clean
- [x] check-edge-imports clean (80 files)
- [ ] CI