### PR TITLE
feat(edge): Sentry adapter for AlertSink (auto-activates on SENTRY_DSN)

### DIFF
--- a/supabase/functions/_shared/alerting-sentry.ts
+++ b/supabase/functions/_shared/alerting-sentry.ts
@@ -1,0 +1,88 @@
+/**
+ * Sentry adapter for AlertSink.
+ *
+ * Activation: set `SENTRY_DSN` in Supabase Edge env config. Once present,
+ * `getAlertSink()` in `alerting.ts` will return this sink instead of the
+ * console default.
+ *
+ * Uses Sentry's lightweight JS SDK via esm.sh, which is Deno-compatible.
+ * The SDK is loaded lazily so functions without a DSN don't pay the
+ * import cost.
+ *
+ * Captures go to the configured environment. Sample rate is fixed at
+ * 1.0 — alerts here are rare (contract violations + unhandled throws)
+ * so we want every one.
+ *
+ * Sentry MCP: with the MCP server connected, queries can confirm events
+ * land (see `find_projects` / `search_issues`). Disable by unsetting the
+ * env var; the sink falls back to console automatically.
+ */
+
+import type { AlertSink, AlertContext } from './alerting.ts'
+
+// Type-only import. The runtime import happens inside `createSentrySink`
+// so functions without a DSN don't bundle the SDK at module-load time.
+type SentryLike = {
+  init(opts: { dsn: string; environment?: string; tracesSampleRate?: number }): void
+  captureException(err: unknown, ctx?: { extra?: Record<string, unknown>; user?: { id?: string } }): string
+  captureMessage(
+    msg: string,
+    ctx?: {
+      level?: 'fatal' | 'error' | 'warning' | 'log' | 'info' | 'debug'
+      extra?: Record<string, unknown>
+      user?: { id?: string }
+    },
+  ): string
+}
+
+/**
+ * Build a Sentry-backed AlertSink. Returns `null` when the DSN is unset
+ * so the caller can fall back to the console sink without a try/catch.
+ *
+ * Wire-up (in a future PR, once DSN is configured):
+ *
+ *   import { createSentrySink } from './alerting-sentry.ts'
+ *   import { setAlertSink } from './alerting.ts'
+ *
+ *   const dsn = Deno.env.get('SENTRY_DSN')
+ *   if (dsn) setAlertSink(await createSentrySink(dsn))
+ */
+export async function createSentrySink(
+  dsn: string,
+  options?: { environment?: string },
+): Promise<AlertSink | null> {
+  if (!dsn) return null
+
+  // Pinned URL; bump deliberately. The Deno-targeted bundle of
+  // @sentry/browser is currently the cleanest path for edge functions.
+  const Sentry: SentryLike = (await import('https://esm.sh/@sentry/browser@8?target=deno')) as unknown as SentryLike
+
+  Sentry.init({
+    dsn,
+    environment: options?.environment ?? 'production',
+    tracesSampleRate: 1.0,
+  })
+
+  return {
+    captureViolation(name, issues, context) {
+      Sentry.captureMessage(`[output_contract_violation] ${name}`, {
+        level: 'error',
+        user: context?.userId ? { id: context.userId } : undefined,
+        extra: {
+          endpoint: name,
+          issues,
+          ...(context?.extra ?? {}),
+        },
+      })
+    },
+    captureException(err, context) {
+      Sentry.captureException(err, {
+        user: context?.userId ? { id: context.userId } : undefined,
+        extra: {
+          endpoint: context?.endpoint,
+          ...(context?.extra ?? {}),
+        },
+      })
+    },
+  }
+}

--- a/supabase/functions/_shared/alerting.ts
+++ b/supabase/functions/_shared/alerting.ts
@@ -64,16 +64,52 @@ export function createConsoleSink(): AlertSink {
 // ---------------------------------------------------------------------------
 // Singleton — resolved lazily so adapter selection can read env vars at
 // first-use time. Tests can inject a sink via `setAlertSink(fakeSink)`.
+//
+// Activation flow:
+//   1. First call to getAlertSink() reads SENTRY_DSN.
+//   2. If set, lazy-imports the Sentry adapter and uses it.
+//   3. If unset (or import fails), falls back to the console sink.
+//
+// Importing the Sentry adapter is async; getAlertSink() returns the
+// console sink synchronously on first call and upgrades to Sentry once
+// the init promise resolves. Concurrent callers in that small window
+// emit through the console — acceptable since these are rare events.
 // ---------------------------------------------------------------------------
 
 let _sink: AlertSink | null = null
+let _sentryInitStarted = false
 
 export function getAlertSink(): AlertSink {
-  if (!_sink) _sink = createConsoleSink()
+  if (_sink) return _sink
+
+  _sink = createConsoleSink()
+
+  if (!_sentryInitStarted) {
+    _sentryInitStarted = true
+    const env = (globalThis as { Deno?: { env: { get(k: string): string | undefined } } }).Deno?.env
+    const dsn = env?.get('SENTRY_DSN')
+    if (dsn) {
+      // Lazy import keeps the SDK out of the bundle when SENTRY_DSN is unset.
+      import('./alerting-sentry.ts')
+        .then(({ createSentrySink }) =>
+          createSentrySink(dsn, {
+            environment: env?.get('SUPABASE_ENVIRONMENT') ?? 'production',
+          }),
+        )
+        .then((sentrySink) => {
+          if (sentrySink) _sink = sentrySink
+        })
+        .catch((err) => {
+          console.error(JSON.stringify({ kind: 'sentry_init_failed', message: String(err) }))
+        })
+    }
+  }
+
   return _sink
 }
 
 /** Test seam. Reset between tests. */
 export function setAlertSink(sink: AlertSink | null): void {
   _sink = sink
+  _sentryInitStarted = sink !== null
 }


### PR DESCRIPTION
Completes #113.

Adds `_shared/alerting-sentry.ts` — Sentry-backed AlertSink using the Deno-compatible `@sentry/browser@8` bundle from esm.sh. Lazy-imported only when `SENTRY_DSN` is set so functions without it don't pay the bundle cost.

`getAlertSink()` now bootstraps Sentry asynchronously on first call:

1. Returns console sink immediately (sync).
2. Kicks off async Sentry init if `SENTRY_DSN` env var is present.
3. Upgrades to Sentry sink once init resolves.

Activation = set `SENTRY_DSN` in Supabase Edge env config. No code change.

If Sentry init fails (network, malformed DSN), alerting.ts logs the failure and stays on console — no edge crash.

## Test plan
- [x] packages/shared 735 pass
- [x] check-edge-imports clean (81 files)
- [ ] CI
- Post-merge with DSN: trigger known violation, verify event lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)