### PR TITLE
feat(telemetry): exception autocapture + search query signals

### DIFF
--- a/web/src/app/search/page.tsx
+++ b/web/src/app/search/page.tsx
@@ -36,8 +36,16 @@ export default function SearchPage() {
     if (query.trim() === '') return
     if (lastTrackedQuery.current === query) return
     lastTrackedQuery.current = query
+    const trimmed = query.trim()
     posthog?.capture('market_search_performed', {
-      query_length: query.trim().length,
+      query_length: trimmed.length,
+      // Low-cardinality, low-PII signals so we can diagnose the 48%
+      // empty-result rate without logging full query strings (#132).
+      query_length_bucket:
+        trimmed.length < 4 ? 'short' :
+        trimmed.length < 8 ? 'med' :
+        trimmed.length < 16 ? 'long' : 'xlong',
+      query_first_word: trimmed.split(/\s+/)[0]?.toLowerCase().slice(0, 20),
       has_results: results.length > 0,
       result_count: results.length,
     })

--- a/web/src/lib/analytics/posthog.tsx
+++ b/web/src/lib/analytics/posthog.tsx
@@ -20,6 +20,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       person_profiles: 'identified_only',
       capture_pageview: false, // we handle this manually below
       capture_pageleave: true,
+      capture_exceptions: true, // uncaught errors + unhandled rejections → $exception events (#135)
       disable_session_recording: true, // start lazily after pageload to avoid blocking first paint
     })
 


### PR DESCRIPTION
Closes #135 and #132.

Two small telemetry wins from the PostHog audit:

- **#135**: `capture_exceptions: true` in posthog.init so uncaught JS errors and unhandled promise rejections produce `$exception` events. Currently zero captured.
- **#132**: `market_search_performed` event gains `query_length_bucket` (short/med/long/xlong) and `query_first_word` (truncated to 20 chars, lowercased) so the 48% empty-result rate can be diagnosed without logging full PII strings.

Verification = one week of post-deploy data:
- query_first_word top 10 → reveals demand surface + data gaps
- $exception trend → reveals real JS errors

## Test plan
- [x] web tsc clean, vitest 372/372
- [ ] CI