### PR TITLE
fix(takeover): capture raw error message when error_reason is 'unknown'

### DIFF
--- a/web/src/app/takeover/[token]/page.test.tsx
+++ b/web/src/app/takeover/[token]/page.test.tsx
@@ -155,7 +155,7 @@ describe('TakeoverPage — PostHog events', () => {
     )
   })
 
-  it('fires takeover_info_load_failed with error_reason: unknown for unrecognised message', async () => {
+  it('fires takeover_info_load_failed with error_reason: unknown + raw message for unrecognised code', async () => {
     mockUseTakeoverInfo.mockReturnValue(infoError('some_completely_unknown_code'))
 
     await renderPage()
@@ -163,6 +163,7 @@ describe('TakeoverPage — PostHog events', () => {
     await waitFor(() =>
       expect(mockCapture).toHaveBeenCalledWith('takeover_info_load_failed', {
         error_reason: 'unknown',
+        error_message_raw: 'some_completely_unknown_code',
       }),
     )
   })

--- a/web/src/app/takeover/[token]/page.tsx
+++ b/web/src/app/takeover/[token]/page.tsx
@@ -28,6 +28,18 @@ function labelFor(err: unknown): string {
   return ERROR_LABEL[msg] ?? msg
 }
 
+/**
+ * Build telemetry payload for a takeover failure. When the error message
+ * matches a known code, only `error_reason` is sent. When it doesn't,
+ * also send a truncated raw message so we can see what we're missing
+ * (#134 — PostHog showed 8 'unknown' events with no diagnostic signal).
+ */
+function failureProps(err: unknown): { error_reason: string; error_message_raw?: string } {
+  const rawMsg = err instanceof Error ? err.message : String(err)
+  if (rawMsg in ERROR_LABEL) return { error_reason: rawMsg }
+  return { error_reason: 'unknown', error_message_raw: rawMsg.slice(0, 200) }
+}
+
 type View =
   | { kind: 'choose' }
   | { kind: 'claim' }
@@ -54,9 +66,7 @@ export default function TakeoverPage({ params }: { params: Promise<{ token: stri
 
   useEffect(() => {
     if (errorTracked || info.isLoading || !info.isError) return
-    const rawMsg = info.error instanceof Error ? info.error.message : String(info.error)
-    const error_reason = rawMsg in ERROR_LABEL ? rawMsg : 'unknown'
-    posthog?.capture('takeover_info_load_failed', { error_reason })
+    posthog?.capture('takeover_info_load_failed', failureProps(info.error))
     setErrorTracked(true)
   }, [info.isError, info.isLoading, info.error, errorTracked, posthog])
 
@@ -407,12 +417,10 @@ function ClaimView({
       })
       setStep('done')
     } catch (err) {
-      const rawMsg = err instanceof Error ? err.message : String(err)
-      const errorCode = rawMsg in ERROR_LABEL ? rawMsg : 'unknown'
       posthog?.capture('takeover_email_submitted', {
         market_id: market.marketId,
         success: false,
-        error_reason: errorCode,
+        ...failureProps(err),
       })
       /* surfaced via start.isError */
     }
@@ -501,12 +509,10 @@ function FeedbackView({
       })
       onDone()
     } catch (err) {
-      const rawMsg = err instanceof Error ? err.message : String(err)
-      const error_reason = rawMsg in ERROR_LABEL ? rawMsg : 'unknown'
       posthog?.capture('takeover_feedback_submitted', {
         market_id: market.marketId,
         success: false,
-        error_reason,
+        ...failureProps(err),
       })
       /* surfaced via feedback.isError */
     }
@@ -585,13 +591,11 @@ function RemoveView({
       })
       onDone()
     } catch (err) {
-      const rawMsg = err instanceof Error ? err.message : String(err)
-      const error_reason = rawMsg in ERROR_LABEL ? rawMsg : 'unknown'
       posthog?.capture('takeover_remove_submitted', {
         market_id: market.marketId,
         success: false,
         has_reason: trimmedReason.length > 0,
-        error_reason,
+        ...failureProps(err),
       })
       /* surfaced via remove.isError */
     }


### PR DESCRIPTION
Closes #134.

PostHog showed 8 `takeover_info_load_failed` events all mapped to `error_reason: 'unknown'` with no diagnostic signal. The mapping table covers 10 known codes; real failures fall through.

New `failureProps()` helper:
- Known code → `{ error_reason: code }` (unchanged)
- Unknown → `{ error_reason: 'unknown', error_message_raw: <truncated 200 chars> }`

Wired into all 4 capture sites (info_load_failed + email/feedback/remove_submitted on failure). After a week of data, the raw messages tell us what to add to the mapping or what edge bug to fix.

## Test plan
- [x] takeover page test: 18/18 pass (1 test updated to assert raw payload)
- [x] web tsc clean
- [ ] CI