### PR TITLE
feat(auth): wire posthog.identify on sign-in, reset on sign-out (root cause of #131)

### DIFF
--- a/web/src/lib/auth/auth-context.tsx
+++ b/web/src/lib/auth/auth-context.tsx
@@ -20,9 +20,11 @@ import {
   createContext,
   useContext,
   useEffect,
+  useRef,
   useState,
   ReactNode,
 } from 'react'
+import posthog from 'posthog-js'
 import type { AuthUser } from '@fyndstigen/shared'
 import { auth, type AuthWithRedirect } from './auth'
 
@@ -49,6 +51,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     })
     return auth.onAuthStateChange(setUser)
   }, [])
+
+  // Keep PostHog identity in sync with Supabase auth so analytics can
+  // distinguish auth vs anonymous users (see #131). Identify on sign-in,
+  // reset on sign-out. Idempotent — posthog.identify dedupes by distinct_id.
+  // The ref prevents reset() from running on the initial null→null render.
+  const lastUserIdRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (user?.id && user.id !== lastUserIdRef.current) {
+      posthog.identify(user.id, { email: user.email })
+      lastUserIdRef.current = user.id
+    } else if (!user && lastUserIdRef.current !== null) {
+      posthog.reset()
+      lastUserIdRef.current = null
+    }
+  }, [user])
 
   return (
     <AuthContext.Provider value={{ user, loading, auth }}>


### PR DESCRIPTION
Investigating #131 (route-builder 97% drop-off) surfaced that `posthog.identify()` was never called.

Every Supabase-signed-in user appears in PostHog as a fresh anonymous distinct_id. Consequences:

1. `$is_identified` is false for everyone, even signed-in users.
2. Auth vs anonymous funnels are meaningless — which is what made the 97% route drop-off look like a UX problem when it was really 1 dev tester (26 of 29 events) + 6 unrelated pageviews across 30 days.
3. `route_login_blocked` correctly didn't fire for the one anon visitor who used the route-builder — because they were probably Supabase-signed-in but PostHog had no way to know.

`AuthProvider` now mirrors Supabase auth state into PostHog. Idempotent (a ref guards against re-identifying with the same id and against `reset()` firing on the initial null→null render).

## Test plan
- [x] auth-context tests 9/9 pass, tsc clean
- [ ] CI
- After deploy: verify a sign-in event produces a PostHog `$identify` event with the right id

🤖 Generated with [Claude Code](https://claude.com/claude-code)