### PR TITLE
fix(perf): replace centered-spinner with skeleton shells (CLS #133)

### DIFF
--- a/web/src/app/utforska/page.tsx
+++ b/web/src/app/utforska/page.tsx
@@ -223,17 +223,20 @@ export default function ExplorePage() {
               </div>
             </div>
 
-            {/* Stats badge */}
-            {markets.length > 0 && (
-              <div className="hidden sm:flex flex-col items-center justify-center bg-mustard/15 rounded-2xl px-6 py-5 min-w-[100px] animate-fade-up delay-4">
-                <span className="font-display text-3xl font-bold text-mustard">
-                  {markets.length}
-                </span>
-                <span className="text-xs text-espresso/65 mt-1 font-medium">
-                  loppisar
-                </span>
-              </div>
-            )}
+            {/* Stats badge — always rendered to reserve space (CLS #133).
+                Number is hidden visually until data loads but the flex
+                container keeps the hero layout stable across states. */}
+            <div className="hidden sm:flex flex-col items-center justify-center bg-mustard/15 rounded-2xl px-6 py-5 min-w-[100px] animate-fade-up delay-4">
+              <span
+                className={`font-display text-3xl font-bold text-mustard transition-opacity ${markets.length > 0 ? 'opacity-100' : 'opacity-0'}`}
+                aria-live="polite"
+              >
+                {markets.length > 0 ? markets.length : ' '}
+              </span>
+              <span className="text-xs text-espresso/65 mt-1 font-medium">
+                loppisar
+              </span>
+            </div>
           </div>
         </div>
       </section>
@@ -262,11 +265,28 @@ export default function ExplorePage() {
         )}
       </section>
 
-      {/* ── Loading ── */}
+      {/* ── Loading skeleton ── */}
+      {/* Reserves the same grid shape the loaded state will use so the
+          paint after data arrives doesn't shift the viewport (CLS #133). */}
       {loading && (
-        <div className="flex items-center justify-center py-20">
-          <FyndstigenLogo size={40} className="text-rust animate-bob" />
-        </div>
+        <section className="mb-10" aria-busy="true" aria-label="Laddar loppisar">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="vintage-card overflow-hidden animate-pulse"
+              >
+                <div className="h-24 sm:h-28 bg-parchment-light border-b border-cream-warm" />
+                <div className="p-5 space-y-2.5">
+                  <div className="h-5 w-3/5 bg-cream-warm rounded" />
+                  <div className="h-4 w-2/5 bg-cream-warm/60 rounded" />
+                  <div className="h-4 w-full bg-cream-warm/40 rounded mt-3" />
+                  <div className="h-4 w-4/5 bg-cream-warm/40 rounded" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
       )}
 
       {/* ── Error state ── */}

--- a/web/src/components/market/detail.test.tsx
+++ b/web/src/components/market/detail.test.tsx
@@ -113,10 +113,10 @@ beforeEach(() => {
 })
 
 describe('MarketDetail', () => {
-  it('shows loading state', () => {
+  it('shows loading skeleton', () => {
     setupMocks({ loading: true, market: null })
-    render(<MarketDetail id="market-1" />)
-    expect(screen.getByTestId('loading')).toBeInTheDocument()
+    const { container } = render(<MarketDetail id="market-1" />)
+    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument()
   })
 
   it('shows "not found" when market does not exist', () => {

--- a/web/src/components/market/detail.tsx
+++ b/web/src/components/market/detail.tsx
@@ -17,9 +17,22 @@ export function MarketDetail({ id }: { id: string }) {
   const { market, tables, images, openingHours, isOwner, editUrl, mapUrl } = vm
 
   if (vm.isLoading) {
+    // Skeleton mirrors the loaded layout (hero + image band + cards) so the
+    // paint after data arrives lands in-place rather than shifting the
+    // viewport (CLS #133).
     return (
-      <div className="flex items-center justify-center py-20">
-        <FyndstigenLogo size={40} className="text-rust animate-bob" />
+      <div className="max-w-3xl mx-auto px-6 py-10" aria-busy="true" aria-label="Laddar loppis">
+        <div className="h-5 w-24 bg-cream-warm rounded mb-6 animate-pulse" />
+        <div className="aspect-[2/1] bg-cream-warm rounded-xl mb-8 animate-pulse" />
+        <div className="space-y-3 animate-pulse">
+          <div className="h-9 w-3/5 bg-cream-warm rounded" />
+          <div className="h-5 w-4/5 bg-cream-warm/60 rounded" />
+        </div>
+        <div className="space-y-4 mt-8 animate-pulse">
+          <div className="h-32 bg-cream-warm/50 rounded-xl" />
+          <div className="h-40 bg-cream-warm/50 rounded-xl" />
+          <div className="h-24 bg-cream-warm/50 rounded-xl" />
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
Closes #133.

PostHog 30-day data showed CLS averaging 0.21 on `/utforska` and 0.15 on `/loppis/[slug]` — both needs-improvement / poor band. Root cause: loading state renders a centered logo where the loaded layout will be; when data arrives the full content replaces it, shifting the viewport.

### Fixes

1. **`/utforska`**: Loading state renders a 6-card skeleton grid using the same `grid-cols / gap` layout the loaded state uses. Hero stats badge always rendered (number fades in) so the flex slot is reserved.

2. **`/loppis/[slug]`**: Loading state mirrors hero + image-band + content-card shape of the loaded layout.

Both have `aria-busy="true"` for accessibility. Market-detail test updated to assert on `aria-busy` instead of the FyndstigenLogo test-id.

### Verification

- After one week of post-deploy data, query CLS by path:
  `SELECT properties.$pathname, avg(toFloat(properties.value)) FROM events WHERE event = 'web_vital' AND properties.name = 'CLS' AND timestamp >= now() - INTERVAL 7 DAY GROUP BY properties.$pathname`

## Test plan
- [x] packages/shared 735, web 372/372 pass (1 pre-existing search-page env failure unchanged), tsc clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)