### PR TITLE
feat(route-builder): "Lägg till i rundan" button on market detail (#139)

### DIFF
--- a/web/e2e/helpers/test.ts
+++ b/web/e2e/helpers/test.ts
@@ -9,10 +9,13 @@ type MapFixtures = {
 
 /**
  * Shared Playwright test. The map profile uses `seedMarkets` and `setNow`
- * to prime `window.__E2E__` after navigation; OSRM requests are auto-
- * intercepted on every page. Smoke tests that don't need these fixtures
- * still work — the `page` override only adds the OSRM handler, which is
- * a no-op unless the code under test calls out to OSRM.
+ * to stage `window.__E2E_PRE_SEED__` / `window.__E2E_NOW__` via
+ * `addInitScript` BEFORE any navigation — so the bridge can drain them
+ * on attach and the first React Query fetch sees data. OSRM requests are
+ * auto-intercepted on every page.
+ *
+ * IMPORTANT: call `seedMarkets`/`setNow` BEFORE the first `page.goto(...)`.
+ * They persist across full reloads in the same test.
  */
 export const test = base.extend<MapFixtures>({
   page: async ({ page }, use) => {
@@ -21,17 +24,15 @@ export const test = base.extend<MapFixtures>({
   },
   seedMarkets: async ({ page }, use) => {
     await use(async (markets) => {
-      await page.waitForFunction(() => !!window.__E2E__)
-      await page.evaluate((m) => {
-        window.__E2E__!.seed(m as unknown as Parameters<NonNullable<typeof window.__E2E__>['seed']>[0])
+      await page.addInitScript((m) => {
+        ;(window as unknown as { __E2E_PRE_SEED__: unknown }).__E2E_PRE_SEED__ = m
       }, markets as unknown as unknown[])
     })
   },
   setNow: async ({ page }, use) => {
     await use(async (iso) => {
-      await page.waitForFunction(() => !!window.__E2E__)
-      await page.evaluate((i) => {
-        window.__E2E__!.setNow(i)
+      await page.addInitScript((i) => {
+        ;(window as unknown as { __E2E_NOW__: string }).__E2E_NOW__ = i
       }, iso)
     })
   },

--- a/web/e2e/map/add-to-route.spec.ts
+++ b/web/e2e/map/add-to-route.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '../helpers/test'
+import { gothenburgMarkets } from '../fixtures/markets'
+
+test.use({ permissions: [] })
+
+const seedWithSlugs = gothenburgMarkets.map((m) => ({ ...m, slug: m.id }))
+
+test.describe('Lägg till i rundan (#139)', () => {
+  test('adds market to draft from detail page and persists to localStorage', async ({
+    page,
+    seedMarkets,
+    setNow,
+  }) => {
+    await seedMarkets(seedWithSlugs)
+    await setNow('2026-04-23T12:00:00Z')
+    await page.goto('/loppis/m1')
+
+    await expect(page.getByRole('heading', { name: 'Kungsportsavenyn Loppis', level: 1 })).toBeVisible()
+
+    const button = page.getByRole('button', { name: /Lägg till i rundan/i })
+    await expect(button).toBeVisible()
+    await expect(button).toHaveAttribute('aria-pressed', 'false')
+
+    await button.click()
+
+    await expect(page.getByRole('button', { name: /I rundan/i })).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.getByRole('status')).toContainText(/Rundan började/)
+    await expect(page.getByRole('link', { name: /Visa rundan/i })).toHaveAttribute('href', '/rundor/skapa')
+
+    const draft = await page.evaluate(() => localStorage.getItem('fyndstigen.route-draft.v1'))
+    expect(draft).not.toBeNull()
+    const parsed = JSON.parse(draft as string)
+    expect(parsed.stops).toEqual([{ marketId: 'm1', index: 0 }])
+  })
+
+  test('reflects existing draft state on reload', async ({ page, seedMarkets, setNow }) => {
+    await seedMarkets(seedWithSlugs)
+    await setNow('2026-04-23T12:00:00Z')
+    await page.goto('/loppis/m1')
+
+    await page.getByRole('button', { name: /Lägg till i rundan/i }).click()
+    await expect(page.getByRole('button', { name: /I rundan/i })).toBeVisible()
+
+    await page.reload()
+    await expect(page.getByRole('button', { name: /I rundan/i })).toBeVisible()
+  })
+
+  test('appending a second market grows the draft and updates copy', async ({ page, seedMarkets, setNow }) => {
+    await seedMarkets(seedWithSlugs)
+    await setNow('2026-04-23T12:00:00Z')
+
+    await page.goto('/loppis/m1')
+    await page.getByRole('button', { name: /Lägg till i rundan/i }).click()
+
+    await page.goto('/loppis/m2')
+    await page.getByRole('button', { name: /Lägg till i rundan/i }).click()
+    await expect(page.getByRole('status')).toContainText(/Du har 2 stopp/)
+
+    const draft = await page.evaluate(() => localStorage.getItem('fyndstigen.route-draft.v1'))
+    const parsed = JSON.parse(draft as string)
+    expect(parsed.stops).toHaveLength(2)
+    expect(parsed.stops.map((s: { marketId: string }) => s.marketId)).toEqual(['m1', 'm2'])
+  })
+})

--- a/web/e2e/map/market-detail.spec.ts
+++ b/web/e2e/map/market-detail.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '../helpers/test'
+import { gothenburgMarkets } from '../fixtures/markets'
+
+test.use({ permissions: [] })
+
+// Slug-as-id E2E shortcut — /loppis/[slug] renders MarketDetail directly
+// under NEXT_PUBLIC_E2E_FAKE without needing a Supabase resolve, so we
+// treat the fixture id as the slug for navigation purposes.
+const seedWithSlugs = gothenburgMarkets.map((m) => ({ ...m, slug: m.id }))
+
+test.describe('/loppis/[slug] — market detail', () => {
+  test('renders the seeded market: name, type stamp, address', async ({ page, seedMarkets, setNow }) => {
+    await seedMarkets(seedWithSlugs)
+    await setNow('2026-04-23T12:00:00Z')
+    await page.goto('/loppis/m1')
+
+    await expect(page.getByRole('heading', { name: 'Kungsportsavenyn Loppis', level: 1 })).toBeVisible()
+    await expect(page.getByText('Permanent')).toBeVisible()
+    await expect(page.getByText('Kungsportsavenyn 1')).toBeVisible()
+    await expect(page.getByText(/Göteborg/)).toBeVisible()
+  })
+
+  test('legacy /fleamarkets/[id] route also renders detail under E2E', async ({ page, seedMarkets, setNow }) => {
+    await seedMarkets(seedWithSlugs)
+    await setNow('2026-04-23T12:00:00Z')
+    await page.goto('/fleamarkets/m2')
+
+    await expect(page.getByRole('heading', { name: 'Haga Loppis', level: 1 })).toBeVisible()
+  })
+})

--- a/web/e2e/map/placeholder.spec.ts
+++ b/web/e2e/map/placeholder.spec.ts
@@ -1,6 +1,0 @@
-// Removed when the first real map test lands (plan 2, task 7).
-import { test, expect } from '../helpers/test'
-
-test('map profile scaffold is wired', () => {
-  expect(process.env.E2E_PROFILE).toBe('map')
-})

--- a/web/e2e/map/utforska.spec.ts
+++ b/web/e2e/map/utforska.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '../helpers/test'
+import { gothenburgMarkets } from '../fixtures/markets'
+
+// Deny geolocation so /utforska falls back to the regular list adapter.
+// The nearby RPC path takes a different code branch (not covered here).
+test.use({ permissions: [] })
+
+test.describe('/utforska — discover markets', () => {
+  test('renders seeded markets with links to canonical detail pages', async ({ page, seedMarkets, setNow }) => {
+    await seedMarkets(gothenburgMarkets.map((m) => ({ ...m, slug: `slug-${m.id}` })))
+    await setNow('2026-04-23T12:00:00Z')
+    await page.goto('/utforska')
+
+    // List adapter results render as cards — assert two distinct markets are visible.
+    await expect(page.getByRole('heading', { name: 'Kungsportsavenyn Loppis' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Haga Loppis' })).toBeVisible()
+
+    // Slug-based URL is the canonical href — the legacy /fleamarkets/[id]
+    // route 308-redirects to /loppis/[slug] server-side. Assert href, not
+    // post-click URL (SSR redirect needs real Supabase).
+    const link = page.getByRole('link', { name: /Kungsportsavenyn Loppis/i }).first()
+    await expect(link).toHaveAttribute('href', '/loppis/slug-m1')
+  })
+
+  test('shows empty state when no markets are seeded', async ({ page, setNow }) => {
+    await setNow('2026-04-23T12:00:00Z')
+    await page.goto('/utforska')
+
+    // The page shouldn't crash, and there should be no market cards rendered.
+    await expect(page.locator('h1, h2, h3').filter({ hasText: /Kungsportsavenyn|Haga/i })).toHaveCount(0)
+  })
+})

--- a/web/src/app/fleamarkets/[id]/page.tsx
+++ b/web/src/app/fleamarkets/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound, permanentRedirect } from 'next/navigation'
 import { createClient } from '@supabase/supabase-js'
 import { createSupabaseServerData } from '@fyndstigen/shared'
+import { MarketDetail } from '@/components/market/detail'
 
 // Legacy UUID URL — 308-redirects to the slug-based canonical /loppis/[slug].
 // 308 (permanent) preserves SEO equity. Existing inbound links from before
@@ -14,6 +15,14 @@ type Props = { params: Promise<{ id: string }> }
 
 export default async function FleaMarketRedirect({ params }: Props) {
   const { id } = await params
+
+  // E2E bypass — skip the Supabase slug lookup and render the detail page
+  // directly. In prod this route is a 308 redirect; tests don't care about
+  // the canonical URL, just that the page renders for the seeded id.
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return <MarketDetail id={id} />
+  }
+
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co',
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder',

--- a/web/src/app/loppis/[slug]/layout.tsx
+++ b/web/src/app/loppis/[slug]/layout.tsx
@@ -63,6 +63,9 @@ const resolveBySlug = cache(async (slug: string) => {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return { title: 'E2E loppis' }
+  }
   const market = await resolveBySlug(slug)
   if (!market) {
     return { title: 'Loppis hittades inte' }
@@ -103,6 +106,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function LoppisLayout({ params, children }: Props) {
   const { slug } = await params
+
+  // E2E bypass — skip the Supabase resolve + JSON-LD. The page handles the
+  // slug-as-id fallback and renders MarketDetail from the in-memory bridge.
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return <>{children}</>
+  }
+
   const market = await resolveBySlug(slug)
   if (!market) notFound()
 

--- a/web/src/app/loppis/[slug]/page.tsx
+++ b/web/src/app/loppis/[slug]/page.tsx
@@ -9,6 +9,18 @@ type Props = { params: Promise<{ slug: string }> }
 
 export default async function LoppisPage({ params }: Props) {
   const { slug } = await params
+
+  // E2E bypass — server-side Supabase isn't available under the in-memory
+  // bridge, so treat slug as id and let the client resolve via deps.
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return (
+      <>
+        <TrackMarketView marketId={slug} slug={slug} />
+        <MarketDetail id={slug} />
+      </>
+    )
+  }
+
   // Cookie-aware client so the logged-in organizer can reach their own
   // unpublished draft. Anon visitors still only resolve published
   // markets via RLS — same policy gates the visibility either way.

--- a/web/src/components/add-to-route-button.test.tsx
+++ b/web/src/components/add-to-route-button.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+import { AddToRouteButton } from './add-to-route-button'
+import { DRAFT_KEY, readDraft } from '@/hooks/route-builder/draft'
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+describe('AddToRouteButton', () => {
+  it('renders the "Lägg till i rundan" label when market not in draft', () => {
+    render(<AddToRouteButton marketId="m-1" source="market_detail" />)
+    expect(screen.getByRole('button')).toHaveTextContent(/Lägg till i rundan/)
+  })
+
+  it('adds the market to the draft on click and shows confirmation', () => {
+    render(<AddToRouteButton marketId="m-1" source="market_detail" />)
+    fireEvent.click(screen.getByRole('button'))
+
+    const draft = readDraft(window.localStorage, Date.now)
+    expect(draft?.stops).toEqual([{ marketId: 'm-1', index: 0 }])
+
+    expect(screen.getByRole('status')).toHaveTextContent(/Rundan började/)
+    expect(screen.getByRole('button')).toHaveTextContent(/I rundan/)
+  })
+
+  it('shows multi-stop confirmation copy when the draft already has stops', () => {
+    window.localStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({
+        name: '',
+        plannedDate: '',
+        useGps: true,
+        customStart: null,
+        stops: [{ marketId: 'm-0', index: 0 }],
+        savedAt: new Date().toISOString(),
+      }),
+    )
+    render(<AddToRouteButton marketId="m-1" source="market_detail" />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByRole('status')).toHaveTextContent(/Du har 2 stopp/)
+  })
+
+  it('reflects existing draft state on mount', () => {
+    window.localStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({
+        name: '',
+        plannedDate: '',
+        useGps: true,
+        customStart: null,
+        stops: [{ marketId: 'm-1', index: 0 }],
+        savedAt: new Date().toISOString(),
+      }),
+    )
+    render(<AddToRouteButton marketId="m-1" source="market_detail" />)
+    expect(screen.getByRole('button')).toHaveTextContent(/I rundan/)
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('does not duplicate when clicked twice', () => {
+    render(<AddToRouteButton marketId="m-1" source="market_detail" />)
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('button'))
+    const draft = readDraft(window.localStorage, Date.now)
+    expect(draft?.stops).toHaveLength(1)
+  })
+
+  it('renders compact variant as an icon button', () => {
+    render(<AddToRouteButton marketId="m-1" source="explore_card" compact />)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveAttribute('aria-label', 'Lägg till i rundan')
+    expect(btn).toHaveTextContent('+')
+  })
+})

--- a/web/src/components/add-to-route-button.tsx
+++ b/web/src/components/add-to-route-button.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { usePostHog } from 'posthog-js/react'
+import { addStopToDraft, isMarketInDraft } from '@/hooks/route-builder/draft'
+
+type Source = 'market_detail' | 'explore_card'
+
+type Props = {
+  marketId: string
+  /** For telemetry; not displayed to the user. */
+  marketName?: string
+  marketCity?: string
+  source: Source
+  /** Compact card-corner variant used on explore listings. */
+  compact?: boolean
+}
+
+/**
+ * "Lägg till i rundan" — surfaces the route-builder draft from anywhere a
+ * market is shown (#139). Reads/writes the same localStorage key as the
+ * route-builder so opening /rundor/skapa picks the markets up via the
+ * existing draft-restore path in useDraftPersistence.
+ *
+ * State is hydrated from localStorage on mount and refreshed on tab focus
+ * so opening this page in two tabs stays consistent.
+ */
+export function AddToRouteButton({
+  marketId,
+  marketName,
+  marketCity,
+  source,
+  compact = false,
+}: Props) {
+  const posthog = usePostHog()
+  const [inRoute, setInRoute] = useState(false)
+  const [justAdded, setJustAdded] = useState(false)
+  const [stopCount, setStopCount] = useState(0)
+
+  // Hydrate on mount + refresh on focus so multi-tab state stays right.
+  useEffect(() => {
+    function refresh() {
+      if (typeof window === 'undefined') return
+      setInRoute(isMarketInDraft(window.localStorage, marketId))
+    }
+    refresh()
+    window.addEventListener('focus', refresh)
+    return () => window.removeEventListener('focus', refresh)
+  }, [marketId])
+
+  // Auto-dismiss the inline confirmation after 4 s.
+  useEffect(() => {
+    if (!justAdded) return
+    const timer = setTimeout(() => setJustAdded(false), 4000)
+    return () => clearTimeout(timer)
+  }, [justAdded])
+
+  function handleClick() {
+    if (typeof window === 'undefined') return
+    if (inRoute) return // Click on "✓ I rundan" is a no-op; user uses the link below to navigate.
+
+    const { draft, added } = addStopToDraft(window.localStorage, marketId)
+    if (!added) return // race-condition guard — shouldn't happen given inRoute check above
+
+    setInRoute(true)
+    setJustAdded(true)
+    setStopCount(draft.stops.length)
+    posthog?.capture('route_market_added_from_detail', {
+      market_id: marketId,
+      market_name: marketName,
+      market_city: marketCity,
+      source,
+      stop_count_after: draft.stops.length,
+    })
+  }
+
+  const compactBase =
+    'inline-flex items-center justify-center w-9 h-9 rounded-full text-white shadow-sm transition-colors'
+  const fullBase =
+    'inline-flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-semibold transition-colors shadow-sm'
+
+  if (compact) {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-label={inRoute ? 'Redan i rundan' : 'Lägg till i rundan'}
+        aria-pressed={inRoute}
+        className={`${compactBase} ${
+          inRoute
+            ? 'bg-forest hover:bg-forest-light'
+            : 'bg-rust hover:bg-rust-light'
+        }`}
+      >
+        {inRoute ? '✓' : '+'}
+      </button>
+    )
+  }
+
+  return (
+    <div className="inline-flex flex-col items-start gap-2">
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-pressed={inRoute}
+        className={`${fullBase} ${
+          inRoute
+            ? 'bg-forest text-white hover:bg-forest-light cursor-default'
+            : 'bg-rust text-white hover:bg-rust-light'
+        }`}
+      >
+        {inRoute ? (
+          <>
+            <span aria-hidden>✓</span> I rundan
+          </>
+        ) : (
+          <>
+            <span aria-hidden className="text-base leading-none">+</span> Lägg till i rundan
+          </>
+        )}
+      </button>
+
+      {justAdded && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="text-xs text-espresso/70 animate-fade-up"
+        >
+          {stopCount === 1
+            ? <>Rundan började — <Link href="/rundor/skapa" className="text-rust font-semibold underline">Visa rundan →</Link></>
+            : <>Tillagd. Du har {stopCount} stopp — <Link href="/rundor/skapa" className="text-rust font-semibold underline">Visa rundan →</Link></>
+          }
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/market/detail.tsx
+++ b/web/src/components/market/detail.tsx
@@ -10,6 +10,7 @@ import { BookableTablesCard } from '@/components/booking/tables-card'
 import { AutoImportedNotice } from '@/components/auto-imported-notice'
 import { ClaimMarketButton } from '@/components/claim-market-button'
 import { MarketImageGallery } from '@/components/market/image-gallery'
+import { AddToRouteButton } from '@/components/add-to-route-button'
 import { useMarketDetailViewModel } from '@/hooks/use-market-detail-view-model'
 
 export function MarketDetail({ id }: { id: string }) {
@@ -156,6 +157,14 @@ export function MarketDetail({ id }: { id: string }) {
       </div>
 
       <div className="mt-8 animate-fade-up delay-5 flex flex-wrap items-center gap-x-6 gap-y-3">
+        {market.publishedAt && (
+          <AddToRouteButton
+            marketId={id}
+            marketName={market.name}
+            marketCity={market.city}
+            source="market_detail"
+          />
+        )}
         <Link
           href={mapUrl}
           className="inline-flex items-center gap-2 text-sm font-medium text-rust hover:text-rust-light transition-colors"

--- a/web/src/hooks/route-builder/draft.test.ts
+++ b/web/src/hooks/route-builder/draft.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  DRAFT_KEY,
+  addStopToDraft,
+  isMarketInDraft,
+  readDraft,
+  writeDraft,
+} from './draft'
+
+function makeStorage(): Storage {
+  const data = new Map<string, string>()
+  return {
+    getItem: (k) => data.get(k) ?? null,
+    setItem: (k, v) => {
+      data.set(k, v)
+    },
+    removeItem: (k) => {
+      data.delete(k)
+    },
+    clear: () => data.clear(),
+    key: () => null,
+    length: 0,
+  } as Storage
+}
+
+describe('addStopToDraft', () => {
+  let storage: Storage
+
+  beforeEach(() => {
+    storage = makeStorage()
+  })
+
+  it('initializes a new draft when none exists', () => {
+    const { draft, added } = addStopToDraft(storage, 'market-1', () => 1000)
+    expect(added).toBe(true)
+    expect(draft.stops).toEqual([{ marketId: 'market-1', index: 0 }])
+    expect(draft.name).toBe('')
+    expect(draft.useGps).toBe(true)
+  })
+
+  it('appends to an existing draft', () => {
+    addStopToDraft(storage, 'market-1', () => 1000)
+    const { draft, added } = addStopToDraft(storage, 'market-2', () => 2000)
+    expect(added).toBe(true)
+    expect(draft.stops).toEqual([
+      { marketId: 'market-1', index: 0 },
+      { marketId: 'market-2', index: 1 },
+    ])
+  })
+
+  it('is idempotent — same marketId returns added=false', () => {
+    addStopToDraft(storage, 'market-1', () => 1000)
+    const { draft, added } = addStopToDraft(storage, 'market-1', () => 2000)
+    expect(added).toBe(false)
+    expect(draft.stops).toHaveLength(1)
+  })
+
+  it('persists the draft so readDraft picks it up', () => {
+    addStopToDraft(storage, 'market-1', () => 1000)
+    const draft = readDraft(storage, () => 2000)
+    expect(draft?.stops).toEqual([{ marketId: 'market-1', index: 0 }])
+  })
+
+  it('preserves existing draft fields (name, plannedDate, useGps) when appending', () => {
+    writeDraft(storage, {
+      name: 'Söndagsrundan',
+      plannedDate: '2026-06-01',
+      useGps: false,
+      customStart: { lat: 59.3, lng: 18.1 },
+      stops: [{ marketId: 'market-1', index: 0 }],
+      savedAt: new Date(1000).toISOString(),
+    })
+    const { draft } = addStopToDraft(storage, 'market-2', () => 2000)
+    expect(draft.name).toBe('Söndagsrundan')
+    expect(draft.plannedDate).toBe('2026-06-01')
+    expect(draft.useGps).toBe(false)
+    expect(draft.customStart).toEqual({ lat: 59.3, lng: 18.1 })
+  })
+})
+
+describe('isMarketInDraft', () => {
+  it('returns false when no draft exists', () => {
+    expect(isMarketInDraft(makeStorage(), 'market-1')).toBe(false)
+  })
+
+  it('returns true when the market is in the draft', () => {
+    const storage = makeStorage()
+    addStopToDraft(storage, 'market-1', () => 1000)
+    expect(isMarketInDraft(storage, 'market-1', () => 2000)).toBe(true)
+  })
+
+  it('returns false for markets not in the draft', () => {
+    const storage = makeStorage()
+    addStopToDraft(storage, 'market-1', () => 1000)
+    expect(isMarketInDraft(storage, 'market-2', () => 2000)).toBe(false)
+  })
+
+  it('returns false when the draft has expired', () => {
+    const storage = makeStorage()
+    addStopToDraft(storage, 'market-1', () => 1000)
+    const eightDaysLater = 1000 + 8 * 24 * 60 * 60 * 1000
+    expect(isMarketInDraft(storage, 'market-1', () => eightDaysLater)).toBe(false)
+  })
+})

--- a/web/src/hooks/route-builder/draft.ts
+++ b/web/src/hooks/route-builder/draft.ts
@@ -45,3 +45,48 @@ export function clearDraft(storage: Storage): void {
     // no-op
   }
 }
+
+/**
+ * Append a market to the draft (or initialize one). Used by the
+ * "Lägg till i rundan" button on market-detail and explore cards (#139)
+ * so users can build a route from outside the route-builder page.
+ *
+ * Idempotent: if the marketId is already in the draft, returns the
+ * existing draft unchanged. Returns the resulting draft so callers can
+ * tell whether the stop count grew (for telemetry / UI confirmation).
+ */
+export function addStopToDraft(
+  storage: Storage,
+  marketId: string,
+  now: () => number = Date.now,
+): { draft: RouteDraft; added: boolean } {
+  const existing = readDraft(storage, now)
+  if (existing?.stops.some((s) => s.marketId === marketId)) {
+    return { draft: existing, added: false }
+  }
+  const base: RouteDraft = existing ?? {
+    name: '',
+    plannedDate: '',
+    useGps: true,
+    customStart: null,
+    stops: [],
+    savedAt: new Date(now()).toISOString(),
+  }
+  const next: RouteDraft = {
+    ...base,
+    stops: [...base.stops, { marketId, index: base.stops.length }],
+    savedAt: new Date(now()).toISOString(),
+  }
+  writeDraft(storage, next)
+  return { draft: next, added: true }
+}
+
+/** Check if a market is already in the current draft. */
+export function isMarketInDraft(
+  storage: Storage,
+  marketId: string,
+  now: () => number = Date.now,
+): boolean {
+  const draft = readDraft(storage, now)
+  return draft?.stops.some((s) => s.marketId === marketId) ?? false
+}

--- a/web/src/lib/e2e/bridge.test.ts
+++ b/web/src/lib/e2e/bridge.test.ts
@@ -63,4 +63,13 @@ describe('createE2EBridge', () => {
     target.__E2E__!.setNow('2026-04-23T12:00:00Z')
     expect(target.__E2E_NOW__).toBe('2026-04-23T12:00:00Z')
   })
+
+  it('drains __E2E_PRE_SEED__ on attach so first query sees seeded data', async () => {
+    target.__E2E_PRE_SEED__ = [makeMarket('fm-pre')]
+    const { deps, control } = createE2EInMemoryDeps()
+    createE2EBridge(control, target)
+    expect(target.__E2E_PRE_SEED__).toBeUndefined()
+    const { count } = await deps.markets.list()
+    expect(count).toBe(1)
+  })
 })

--- a/web/src/lib/e2e/bridge.ts
+++ b/web/src/lib/e2e/bridge.ts
@@ -11,6 +11,12 @@ declare global {
   interface Window {
     __E2E__?: E2EBridge
     __E2E_NOW__?: string
+    /**
+     * Pre-navigation seed — set via `page.addInitScript` so it lands on the
+     * window before the React tree mounts. The bridge drains it on attach,
+     * which means the very first React Query fetch sees seeded data.
+     */
+    __E2E_PRE_SEED__?: StoredMarket[]
   }
 }
 
@@ -34,5 +40,12 @@ export function createE2EBridge(control: E2EControl, target: Window): E2EBridge 
     },
   }
   target.__E2E__ = bridge
+  // Drain any pre-seed staged via Playwright's addInitScript so the first
+  // query render sees data, not an empty store.
+  const preSeed = target.__E2E_PRE_SEED__
+  if (preSeed && preSeed.length > 0) {
+    bridge.seed(preSeed)
+    target.__E2E_PRE_SEED__ = undefined
+  }
   return bridge
 }


### PR DESCRIPTION
## Summary
Closes #139. Adds a "+ Lägg till i rundan" button to market-detail pages that drops the market into the same `fyndstigen.route-draft.v1` localStorage draft the route-builder restores from — fixing the discovery gap where users could browse markets but not start a route from them.

- New helpers `addStopToDraft` / `isMarketInDraft` in `web/src/hooks/route-builder/draft.ts` (idempotent; preserves existing draft fields)
- New `AddToRouteButton` component with a full and a compact variant (compact ready for an explore-card follow-up)
- Wired into `web/src/components/market/detail.tsx`; hidden for unpublished markets
- `route_market_added_from_detail` PostHog event with `{ market_id, market_name, market_city, source, stop_count_after }`
- Hydrates state on mount + on window `focus`, so navigating back from `/rundor/skapa` reflects the latest draft
- Inline status message ("Rundan började" / "Du har N stopp — Visa rundan →") with a 4s auto-dismiss; no toast library needed
- **End-to-end Playwright coverage of the full add-to-route flow** (3 scenarios: first add, reload persistence, multi-stop append)

## Stacked on #142
This branch is rebased on top of `test/e2e-map-utforska` (#142), which adds the bridge pre-seed mechanism and SSR bypass that the e2e specs need. **Merge #142 first.**

## Test plan
- [x] `vitest run` — 15 new unit tests (draft helpers + button), full suite 387 pass (one pre-existing unrelated env failure in search/page.test.tsx)
- [x] `tsc --noEmit` — clean
- [x] `npm run e2e:map` — 7/7 pass (utforska × 2, market-detail × 2, add-to-route × 3)
- [ ] Smoke on staging once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)