### PR TITLE
test(e2e): real /utforska map suite — pre-seed bridge for first query

### DIFF
--- a/web/e2e/helpers/test.ts
+++ b/web/e2e/helpers/test.ts
@@ -9,10 +9,13 @@ type MapFixtures = {
 
 /**
  * Shared Playwright test. The map profile uses `seedMarkets` and `setNow`
- * to prime `window.__E2E__` after navigation; OSRM requests are auto-
- * intercepted on every page. Smoke tests that don't need these fixtures
- * still work — the `page` override only adds the OSRM handler, which is
- * a no-op unless the code under test calls out to OSRM.
+ * to stage `window.__E2E_PRE_SEED__` / `window.__E2E_NOW__` via
+ * `addInitScript` BEFORE any navigation — so the bridge can drain them
+ * on attach and the first React Query fetch sees data. OSRM requests are
+ * auto-intercepted on every page.
+ *
+ * IMPORTANT: call `seedMarkets`/`setNow` BEFORE the first `page.goto(...)`.
+ * They persist across full reloads in the same test.
  */
 export const test = base.extend<MapFixtures>({
   page: async ({ page }, use) => {
@@ -21,17 +24,15 @@ export const test = base.extend<MapFixtures>({
   },
   seedMarkets: async ({ page }, use) => {
     await use(async (markets) => {
-      await page.waitForFunction(() => !!window.__E2E__)
-      await page.evaluate((m) => {
-        window.__E2E__!.seed(m as unknown as Parameters<NonNullable<typeof window.__E2E__>['seed']>[0])
+      await page.addInitScript((m) => {
+        ;(window as unknown as { __E2E_PRE_SEED__: unknown }).__E2E_PRE_SEED__ = m
       }, markets as unknown as unknown[])
     })
   },
   setNow: async ({ page }, use) => {
     await use(async (iso) => {
-      await page.waitForFunction(() => !!window.__E2E__)
-      await page.evaluate((i) => {
-        window.__E2E__!.setNow(i)
+      await page.addInitScript((i) => {
+        ;(window as unknown as { __E2E_NOW__: string }).__E2E_NOW__ = i
       }, iso)
     })
   },

--- a/web/e2e/map/market-detail.spec.ts
+++ b/web/e2e/map/market-detail.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '../helpers/test'
+import { gothenburgMarkets } from '../fixtures/markets'
+
+test.use({ permissions: [] })
+
+// Slug-as-id E2E shortcut — /loppis/[slug] renders MarketDetail directly
+// under NEXT_PUBLIC_E2E_FAKE without needing a Supabase resolve, so we
+// treat the fixture id as the slug for navigation purposes.
+const seedWithSlugs = gothenburgMarkets.map((m) => ({ ...m, slug: m.id }))
+
+test.describe('/loppis/[slug] — market detail', () => {
+  test('renders the seeded market: name, type stamp, address', async ({ page, seedMarkets, setNow }) => {
+    await seedMarkets(seedWithSlugs)
+    await setNow('2026-04-23T12:00:00Z')
+    await page.goto('/loppis/m1')
+
+    await expect(page.getByRole('heading', { name: 'Kungsportsavenyn Loppis', level: 1 })).toBeVisible()
+    await expect(page.getByText('Permanent')).toBeVisible()
+    await expect(page.getByText('Kungsportsavenyn 1')).toBeVisible()
+    await expect(page.getByText(/Göteborg/)).toBeVisible()
+  })
+
+  test('legacy /fleamarkets/[id] route also renders detail under E2E', async ({ page, seedMarkets, setNow }) => {
+    await seedMarkets(seedWithSlugs)
+    await setNow('2026-04-23T12:00:00Z')
+    await page.goto('/fleamarkets/m2')
+
+    await expect(page.getByRole('heading', { name: 'Haga Loppis', level: 1 })).toBeVisible()
+  })
+})

--- a/web/e2e/map/placeholder.spec.ts
+++ b/web/e2e/map/placeholder.spec.ts
@@ -1,6 +1,0 @@
-// Removed when the first real map test lands (plan 2, task 7).
-import { test, expect } from '../helpers/test'
-
-test('map profile scaffold is wired', () => {
-  expect(process.env.E2E_PROFILE).toBe('map')
-})

--- a/web/e2e/map/utforska.spec.ts
+++ b/web/e2e/map/utforska.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '../helpers/test'
+import { gothenburgMarkets } from '../fixtures/markets'
+
+// Deny geolocation so /utforska falls back to the regular list adapter.
+// The nearby RPC path takes a different code branch (not covered here).
+test.use({ permissions: [] })
+
+test.describe('/utforska — discover markets', () => {
+  test('renders seeded markets with links to canonical detail pages', async ({ page, seedMarkets, setNow }) => {
+    await seedMarkets(gothenburgMarkets.map((m) => ({ ...m, slug: `slug-${m.id}` })))
+    await setNow('2026-04-23T12:00:00Z')
+    await page.goto('/utforska')
+
+    // List adapter results render as cards — assert two distinct markets are visible.
+    await expect(page.getByRole('heading', { name: 'Kungsportsavenyn Loppis' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Haga Loppis' })).toBeVisible()
+
+    // Slug-based URL is the canonical href — the legacy /fleamarkets/[id]
+    // route 308-redirects to /loppis/[slug] server-side. Assert href, not
+    // post-click URL (SSR redirect needs real Supabase).
+    const link = page.getByRole('link', { name: /Kungsportsavenyn Loppis/i }).first()
+    await expect(link).toHaveAttribute('href', '/loppis/slug-m1')
+  })
+
+  test('shows empty state when no markets are seeded', async ({ page, setNow }) => {
+    await setNow('2026-04-23T12:00:00Z')
+    await page.goto('/utforska')
+
+    // The page shouldn't crash, and there should be no market cards rendered.
+    await expect(page.locator('h1, h2, h3').filter({ hasText: /Kungsportsavenyn|Haga/i })).toHaveCount(0)
+  })
+})

--- a/web/src/app/fleamarkets/[id]/page.tsx
+++ b/web/src/app/fleamarkets/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound, permanentRedirect } from 'next/navigation'
 import { createClient } from '@supabase/supabase-js'
 import { createSupabaseServerData } from '@fyndstigen/shared'
+import { MarketDetail } from '@/components/market/detail'
 
 // Legacy UUID URL — 308-redirects to the slug-based canonical /loppis/[slug].
 // 308 (permanent) preserves SEO equity. Existing inbound links from before
@@ -14,6 +15,14 @@ type Props = { params: Promise<{ id: string }> }
 
 export default async function FleaMarketRedirect({ params }: Props) {
   const { id } = await params
+
+  // E2E bypass — skip the Supabase slug lookup and render the detail page
+  // directly. In prod this route is a 308 redirect; tests don't care about
+  // the canonical URL, just that the page renders for the seeded id.
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return <MarketDetail id={id} />
+  }
+
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co',
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder',

--- a/web/src/app/loppis/[slug]/layout.tsx
+++ b/web/src/app/loppis/[slug]/layout.tsx
@@ -63,6 +63,9 @@ const resolveBySlug = cache(async (slug: string) => {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return { title: 'E2E loppis' }
+  }
   const market = await resolveBySlug(slug)
   if (!market) {
     return { title: 'Loppis hittades inte' }
@@ -103,6 +106,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function LoppisLayout({ params, children }: Props) {
   const { slug } = await params
+
+  // E2E bypass — skip the Supabase resolve + JSON-LD. The page handles the
+  // slug-as-id fallback and renders MarketDetail from the in-memory bridge.
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return <>{children}</>
+  }
+
   const market = await resolveBySlug(slug)
   if (!market) notFound()
 

--- a/web/src/app/loppis/[slug]/page.tsx
+++ b/web/src/app/loppis/[slug]/page.tsx
@@ -9,6 +9,18 @@ type Props = { params: Promise<{ slug: string }> }
 
 export default async function LoppisPage({ params }: Props) {
   const { slug } = await params
+
+  // E2E bypass — server-side Supabase isn't available under the in-memory
+  // bridge, so treat slug as id and let the client resolve via deps.
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return (
+      <>
+        <TrackMarketView marketId={slug} slug={slug} />
+        <MarketDetail id={slug} />
+      </>
+    )
+  }
+
   // Cookie-aware client so the logged-in organizer can reach their own
   // unpublished draft. Anon visitors still only resolve published
   // markets via RLS — same policy gates the visibility either way.

--- a/web/src/lib/e2e/bridge.test.ts
+++ b/web/src/lib/e2e/bridge.test.ts
@@ -63,4 +63,13 @@ describe('createE2EBridge', () => {
     target.__E2E__!.setNow('2026-04-23T12:00:00Z')
     expect(target.__E2E_NOW__).toBe('2026-04-23T12:00:00Z')
   })
+
+  it('drains __E2E_PRE_SEED__ on attach so first query sees seeded data', async () => {
+    target.__E2E_PRE_SEED__ = [makeMarket('fm-pre')]
+    const { deps, control } = createE2EInMemoryDeps()
+    createE2EBridge(control, target)
+    expect(target.__E2E_PRE_SEED__).toBeUndefined()
+    const { count } = await deps.markets.list()
+    expect(count).toBe(1)
+  })
 })

--- a/web/src/lib/e2e/bridge.ts
+++ b/web/src/lib/e2e/bridge.ts
@@ -11,6 +11,12 @@ declare global {
   interface Window {
     __E2E__?: E2EBridge
     __E2E_NOW__?: string
+    /**
+     * Pre-navigation seed — set via `page.addInitScript` so it lands on the
+     * window before the React tree mounts. The bridge drains it on attach,
+     * which means the very first React Query fetch sees seeded data.
+     */
+    __E2E_PRE_SEED__?: StoredMarket[]
   }
 }
 
@@ -34,5 +40,12 @@ export function createE2EBridge(control: E2EControl, target: Window): E2EBridge 
     },
   }
   target.__E2E__ = bridge
+  // Drain any pre-seed staged via Playwright's addInitScript so the first
+  // query render sees data, not an empty store.
+  const preSeed = target.__E2E_PRE_SEED__
+  if (preSeed && preSeed.length > 0) {
+    bridge.seed(preSeed)
+    target.__E2E_PRE_SEED__ = undefined
+  }
   return bridge
 }


### PR DESCRIPTION
## Summary
Replaces the map-profile placeholder spec with real Playwright tests, and unblocks end-to-end coverage of any client-rendered surface by fixing two infrastructure gaps:

1. **Bridge timing** — the original `seedMarkets` helper called `seed()` after `goto`, but React Query had already fetched empty by then. New approach: stage data on `window.__E2E_PRE_SEED__` via `addInitScript` before navigation, and have the bridge drain it on attach.
2. **SSR bypass for market detail** — `/loppis/[slug]` and `/fleamarkets/[id]` both ran Supabase queries server-side before any client code mounted, so the in-memory bridge couldn't reach them. Added a small `NEXT_PUBLIC_E2E_FAKE` branch in each route that renders directly from the in-memory deps (treats slug as id under E2E; prod behavior unchanged).

### Tests added
- `e2e/map/utforska.spec.ts` — list renders seeded markets with canonical `/loppis/[slug]` hrefs; empty-state path
- `e2e/map/market-detail.spec.ts` — `/loppis/m1` renders name, type stamp, address; legacy `/fleamarkets/m2` route also resolves

### Code changes
- `web/src/lib/e2e/bridge.ts` — drain `__E2E_PRE_SEED__` on attach (+ unit test)
- `web/e2e/helpers/test.ts` — `seedMarkets` / `setNow` now use `addInitScript`
- `web/src/app/loppis/[slug]/page.tsx` + `layout.tsx` — short-circuit under E2E_FAKE
- `web/src/app/fleamarkets/[id]/page.tsx` — render `MarketDetail` instead of 308 redirect under E2E_FAKE
- Drop `placeholder.spec.ts`

## Why this matters
PR #141 (add-to-route button) is stacked on this branch — its e2e tests need both the bridge pre-seed and the SSR bypass to drive the full flow.

## Test plan
- [x] `npm run e2e:map` — 4/4 pass
- [x] `npm run e2e:smoke` — 9/9 pass (unaffected)
- [x] Bridge unit suite — 5/5 pass
- [x] `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)