### PR TITLE
refactor: migrate remaining @/lib/geo callers to useDeps().geo

### DIFF
--- a/web/src/components/map-view.tsx
+++ b/web/src/components/map-view.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { useMap } from 'react-leaflet'
-import { geo } from '@/lib/geo'
+import { useDeps } from '@/providers/deps-provider'
 import { supabase } from '@/lib/supabase'
 import type { FleaMarketNearByView } from '@fyndstigen/shared'
 import { marketUrl } from '@/lib/urls'
@@ -31,6 +31,7 @@ function FlyToLocation({ lat, lng, zoom }: { lat: number; lng: number; zoom: num
 }
 
 export default function MapView() {
+  const { geo } = useDeps()
   const params = useSearchParams()
   // Allow callers (e.g. /loppis/[slug]'s "Visa på karta"-link) to deep-link
   // straight to a market's coordinates instead of opening the general map

--- a/web/src/hooks/market-form/use-market-form.test.ts
+++ b/web/src/hooks/market-form/use-market-form.test.ts
@@ -9,17 +9,10 @@ import { useMarketForm } from './use-market-form'
 global.URL.createObjectURL = vi.fn((f: File) => `blob:${f.name}`)
 global.URL.revokeObjectURL = vi.fn()
 
-vi.mock('@/lib/geo', () => ({
-  geo: {
-    geocode: vi.fn().mockResolvedValue({ lat: 59.33, lng: 18.07 }),
-  },
-}))
-
-import { geo } from '@/lib/geo'
-
 // Build the in-memory Deps object ONCE — DepsProvider expects a stable reference.
 // We spy on individual adapter methods per-test inside each describe block.
 const testDeps: Deps = makeInMemoryDeps()
+const geo = testDeps.geo
 
 function createWrapper(deps: Deps = testDeps) {
   return ({ children }: { children: React.ReactNode }) =>
@@ -29,7 +22,7 @@ function createWrapper(deps: Deps = testDeps) {
 describe('useMarketForm — create mode', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(geo.geocode).mockResolvedValue({ lat: 59.33, lng: 18.07 })
+    vi.spyOn(geo, 'geocode').mockResolvedValue({ lat: 59.33, lng: 18.07 })
     // Re-apply default spies on the in-memory adapters for clean per-test state.
     vi.spyOn(testDeps.markets, 'create').mockResolvedValue({ id: 'market-1' })
     vi.spyOn(testDeps.markets, 'publish').mockResolvedValue(undefined)
@@ -91,7 +84,7 @@ describe('useMarketForm — create mode', () => {
   })
 
   it('submit: surfaces geocode error as Swedish message', async () => {
-    vi.mocked(geo.geocode).mockRejectedValue(new GeocodeError('nowhere'))
+    vi.spyOn(geo, 'geocode').mockRejectedValue(new GeocodeError('nowhere'))
     const { result } = renderHook(
       () => useMarketForm({ mode: 'create', organizerId: 'user-1' }),
       { wrapper: createWrapper() },
@@ -108,7 +101,7 @@ describe('useMarketForm — create mode', () => {
 describe('useMarketForm — edit mode', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(geo.geocode).mockResolvedValue({ lat: 59.33, lng: 18.07 })
+    vi.spyOn(geo, 'geocode').mockResolvedValue({ lat: 59.33, lng: 18.07 })
     vi.spyOn(testDeps.markets, 'create').mockResolvedValue({ id: 'market-1' })
     vi.spyOn(testDeps.markets, 'publish').mockResolvedValue(undefined)
     vi.spyOn(testDeps.markets, 'update').mockResolvedValue(undefined)

--- a/web/src/hooks/market-form/use-submit-market.ts
+++ b/web/src/hooks/market-form/use-submit-market.ts
@@ -1,7 +1,6 @@
 'use client'
 
 import { useCallback, useRef, useState } from 'react'
-import { geo } from '@/lib/geo'
 import { runMarketMutation } from '@fyndstigen/shared'
 import { useDeps } from '@/providers/deps-provider'
 import { messageFor } from '@fyndstigen/shared'
@@ -53,7 +52,7 @@ export function useSubmitMarket(opts: UseSubmitMarketOptions): {
   clearError: () => void
   clearSuccess: () => void
 } {
-  const { markets, marketTables, images: imagesPort } = useDeps()
+  const { markets, marketTables, images: imagesPort, geo } = useDeps()
 
   // Keep latest opts in a ref so submit() never goes stale.
   const optsRef = useRef(opts)

--- a/web/src/hooks/use-route-builder.test.tsx
+++ b/web/src/hooks/use-route-builder.test.tsx
@@ -47,16 +47,6 @@ vi.mock('@/lib/auth/auth-context', () => ({
   useAuth: () => ({ user: null }),
 }))
 
-// Mock the geo module so the test doesn't transitively load @/lib/supabase
-// (which throws under jsdom without env vars). Tests inject geo via deps.
-vi.mock('@/lib/geo', () => ({
-  geo: {
-    nearbyMarkets: vi.fn(async () => []),
-    optimizeStops: vi.fn((stops) => stops),
-    geocode: vi.fn(),
-  },
-}))
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/web/src/lib/geo.ts
+++ b/web/src/lib/geo.ts
@@ -1,3 +1,0 @@
-import { createGeo } from '@fyndstigen/shared'
-import { supabase } from './supabase'
-export const geo = createGeo(supabase)


### PR DESCRIPTION
## Summary
#143 added `GeoService` to the `Deps` container but only migrated the route-builder. Two other consumers still imported the static `@/lib/geo` singleton:

- `use-submit-market.ts` — geocoding new market addresses before save
- `map-view.tsx` — fetching nearby markets for the public `/map` page

Both now read `geo` from `useDeps()`. With no callers left, `web/src/lib/geo.ts` is deleted; production wiring lives in `makeSupabaseDeps`, in-memory in `makeInMemoryDeps` / `createE2EInMemoryDeps`.

## Test fallout
- `use-market-form.test.ts` swaps `vi.mock('@/lib/geo', ...)` for `vi.spyOn(testDeps.geo, 'geocode')` (the in-memory `geo` is already there)
- `use-route-builder.test.tsx` drops a `vi.mock('@/lib/geo')` that was only there to dodge the transitive `@/lib/supabase` import — no longer reachable now that nothing imports `@/lib/geo`

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 388 pass (one pre-existing unrelated env failure in search/page.test.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)