### PR TITLE
test(e2e): SSR bypass for /arrangorer/[id] and /kvartersloppis/[slug]

### DIFF
--- a/web/e2e/map/dynamic-routes.spec.ts
+++ b/web/e2e/map/dynamic-routes.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '../helpers/test'
+
+test.use({ permissions: [] })
+
+// Smoke-level coverage for routes whose layouts previously did blocking
+// server-side Supabase calls. The bypass under NEXT_PUBLIC_E2E_FAKE skips
+// the resolve so the client tree mounts; we don't seed deps here so the
+// hooks land in their "not found" / error state — that itself proves the
+// layout no longer 500s and the client component reached its data branch.
+
+test.describe('SSR bypass — dynamic detail routes', () => {
+  test('/arrangorer/[id] renders the not-found branch when organizer unseeded', async ({ page }) => {
+    await page.goto('/arrangorer/nonexistent')
+    await expect(page.getByRole('heading', { name: /Arrangören hittades inte/i })).toBeVisible()
+  })
+
+  test('/kvartersloppis/[slug] renders the error branch when slug unseeded', async ({ page }) => {
+    await page.goto('/kvartersloppis/nonexistent')
+    await expect(page.getByText(/Kunde inte ladda kvartersloppis|Laddar/i)).toBeVisible()
+  })
+})

--- a/web/src/app/arrangorer/[id]/layout.tsx
+++ b/web/src/app/arrangorer/[id]/layout.tsx
@@ -20,6 +20,9 @@ function getServerData() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return { title: 'E2E arrangör' }
+  }
   const organizer = await getServerData().getOrganizerMeta(id)
   if (!organizer) {
     return { title: 'Arrangören hittades inte' }
@@ -43,6 +46,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function OrganizerLayout({ params, children }: Props) {
   const { id } = await params
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return <>{children}</>
+  }
   const organizer = await getServerData().getOrganizerMeta(id)
 
   const jsonLd = organizer

--- a/web/src/app/kvartersloppis/[slug]/layout.tsx
+++ b/web/src/app/kvartersloppis/[slug]/layout.tsx
@@ -34,6 +34,9 @@ const resolve = cache(async (slug: string) => {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return { title: 'E2E kvartersloppis' }
+  }
   const bs = await resolve(slug)
   if (!bs) return { title: 'Kvartersloppis hittades inte' }
   const isDraft = !bs.publishedAt
@@ -48,6 +51,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function Layout({ params, children }: Props) {
   const { slug } = await params
+  if (process.env.NEXT_PUBLIC_E2E_FAKE === '1') {
+    return <>{children}</>
+  }
   const bs = await resolve(slug)
   if (!bs) notFound()
 


### PR DESCRIPTION
## Summary
Both routes' layouts ran blocking server-side Supabase queries (`getOrganizerMeta`, `getBlockSaleMeta`) that crashed under `NEXT_PUBLIC_E2E_FAKE` because the in-memory bridge only reaches client-side code. Same shape of bypass as #142's `/loppis/[slug]`: skip the resolve + JSON-LD under E2E, pass children through. Production behavior unchanged.

Both page bodies are already client components reading via `useDeps()`, so deeper coverage (asserting on real organizer/block-sale data) can come once the in-memory adapters gain seed APIs for those stores — out of scope here.

## Tests
- `e2e/map/dynamic-routes.spec.ts` (new) — navigating with an unseeded id/slug lands on the client-side "not found" / error branch instead of an SSR 500

## Test plan
- [x] `npm run e2e:map` — passing
- [x] `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)